### PR TITLE
Story/24/invite new members

### DIFF
--- a/app/assets/stylesheets/_mailer.scss
+++ b/app/assets/stylesheets/_mailer.scss
@@ -1,0 +1,108 @@
+// VARS
+// ----------------------------------------
+
+//---- Colors -----
+$success-color: #2ecc71;
+$light-grey: #b3b3b3;
+$dark-grey: #626262;
+
+
+//---- Fonts -----
+$font-family-sans-serif: "aktiv-grotesk", Helvetica, sans-serif;
+$font-weight-normal: 400;
+$font-weight-bold: 700;
+
+// ----------------------------------------
+
+// Invitation to project email
+// ----------------------------------------
+
+html,
+body {
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+body {
+  color: $dark-grey;
+  font-family: $font-family-sans-serif;
+  font-weight: $font-weight-normal;
+  min-height: 100%;
+}//body
+
+.btn-green {
+  background-color: $success-color;
+  border: 2px solid $success-color;
+  border-radius: $global-radius;
+  color: $white;
+  cursor: pointer;
+  display: block;
+  font-family: $font-family-sans-serif;
+  font-size: rem-calc(15);
+  font-weight: $font-weight-bold;
+  margin: 0 auto;
+  padding: rem-calc(10 25);
+  text-align: center;
+  text-decoration: none;
+
+  &:hover:enabled {
+    background-color: $white;
+    color: $success-color;
+  }//hover
+}//btn-green
+
+.btn-grey {
+  background-color: $light-grey;
+  border: 2px solid $light-grey;
+  border-radius: $global-radius;
+  color: $white;
+  cursor: pointer;
+  display: block;
+  font-family: $font-family-sans-serif;
+  font-size: rem-calc(15);
+  font-weight: $font-weight-bold;
+  margin: 0 auto;
+  padding: rem-calc(10 25);
+  text-align: center;
+  text-decoration: none;
+
+  &:hover:enabled {
+    background-color: $white;
+    color: $success-color;
+  }//hover
+}//btn-grey
+
+.emphasized-text {
+  color: $success-color;
+  font-weight: $font-weight-bold;
+}
+
+.content {
+  display: block;
+  margin: 0 auto;
+  width: rem-calc(550);
+}
+
+.logo {
+  content: url('/images/arbor-logo.svg');
+  cursor: default;
+  font-size: rem-calc(17);
+  font-weight: $font-weight-normal;
+  margin: 0 auto;
+  padding-top: rem-calc(30);
+  width: rem-calc(120);
+
+  &:hover {
+    color: $white;
+    padding: rem-calc(13 15);
+  }//hover
+}
+
+.tagline {
+  color: $light-grey;
+  font-size: rem-calc(12);
+  margin: 10px auto 35px;
+  text-align: center;
+}
+// ----------------------------------------

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,14 +1,27 @@
 class RegistrationsController < Devise::RegistrationsController
   before_action :resource_name
   skip_before_action :authenticate_user!
+  after_action :add_member_to_projects, only: :create
 
   def new
     redirect_to new_user_session_path
+  end
+
+  def create
+    super
   end
 
   private
 
   def resource_name
     :user
+  end
+
+  def add_member_to_projects
+    email = params[:user][:email]
+    Invite.where(email: email).each do |invite|
+      invite.project.members << User.find_by(email: email)
+      Invite.destroy(invite)
+    end
   end
 end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,0 +1,11 @@
+class InviteMailer < ActionMailer::Base
+  default from: ENV['FROM_EMAIL_ADDRESS']
+
+  def project_invite_email(data, is_new)
+    @project_name = data[:project_name]
+    @inviter = data[:inviter]
+    @is_new = is_new
+
+    mail to: data[:email], subject: t('mailer.invite.subject')
+  end
+end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,0 +1,6 @@
+class Invite < ActiveRecord::Base
+  validates_presence_of :email
+  validates_presence_of :project
+
+  belongs_to :project
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ActiveRecord::Base
   has_many :members_projects, class_name: MembersProject
   has_many :members, class_name: User, through: :members_projects
   has_many :hypotheses, dependent: :destroy
+  has_many :invites, dependent: :destroy
   has_one :canvas, dependent: :destroy
   has_many :user_stories, dependent: :destroy
 

--- a/app/services/project_member_services.rb
+++ b/app/services/project_member_services.rb
@@ -1,0 +1,44 @@
+class ProjectMemberServices
+  def initialize(project, current_user, emails)
+    @project = project
+    @current_user = current_user
+    @inviter = current_user.full_name
+    @emails = emails
+  end
+
+  def invite_members
+    project_members = []
+    @emails.each do |email|
+      project_members << process_email(email)
+    end
+    @project.members = project_members.compact << @current_user
+  end
+
+  private
+
+  def process_email(email)
+    user = User.find_by(email: email)
+    data = {
+      project_name: @project.name,
+      email:        email,
+      inviter:      @inviter
+    }
+    if user
+      invite_user_to_project(user, data)
+      return user
+    end
+
+    invite_new_user(data)
+    nil
+  end
+
+  def invite_user_to_project(user, data)
+    return if @project.members.exists?(user.id)
+    InviteMailer.project_invite_email(data, false).deliver_now
+  end
+
+  def invite_new_user(data)
+    Invite.create(email: data[:email], project: @project)
+    InviteMailer.project_invite_email(data, true).deliver_now
+  end
+end

--- a/app/views/invite_mailer/project_invite_email.html.haml
+++ b/app/views/invite_mailer/project_invite_email.html.haml
@@ -1,0 +1,18 @@
+%html
+  %head
+    %meta{ 'content' => 'text/html; charset=UTF-8', 'http-equiv' => 'Content-Type' }
+    =stylesheet_link_tag 'mailer'
+  %body
+    .logo
+    .content
+      .tagline= t("mailer.invite.title")
+      = t("mailer.invite.someone_invited_you", inviter: @inviter, project_name: @project_name).html_safe
+
+      %p= t("mailer.invite.description").html_safe
+      %p= t("mailer.invite.get_started").html_safe
+      - if @is_new
+        %p= link_to t("mailer.invite.create_account"), root_url, class: 'btn-green'
+      - else
+        %p= link_to t("mailer.invite.view_project"), root_url, class: 'btn-green'
+      %p= t("mailer.invite.thanks").html_safe
+      %p= t("mailer.invite.arbor").html_safe

--- a/app/views/invite_mailer/project_invite_email.text.haml
+++ b/app/views/invite_mailer/project_invite_email.text.haml
@@ -1,0 +1,19 @@
+BE A BETTER PRODUCT OWNER
+\
+\
+= @inviter
+invited you to collaborate on a project called
+= @project_name
+in Arbor.
+\
+\
+Arbor is the most effective way to distill your idea into an actionable roadmap that your team can use to define and build out your product.
+\
+\
+To get started, click on the button below:
+\
+\
+View project,
+Thanks!
+\
+\- Arbor Team

--- a/app/views/projects/show.haml
+++ b/app/views/projects/show.haml
@@ -12,3 +12,14 @@
         %td
           = member.email
 = link_to 'Edit', edit_project_path(@project)
+.sent_invites
+  %h3
+    - unless @invites.empty?
+      Sent Invites
+      %table
+        %tr
+          %th Email
+        - @invites.each do |invite|
+          %tr
+            %td
+              = invite.email

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,4 +8,6 @@ Railsroot::Application.configure do
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load
   config.assets.debug = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,3 +68,14 @@ en:
   csv: "CSV"
   json: "Json"
   trello: "Export to Trello"
+  mailer:
+    invite:
+      subject: 'Invitation instructions'
+      title: 'Be a better product owner'
+      someone_invited_you: '%{inviter} invited you to collaborate on a project called %{project_name} in Arbor.'
+      description: 'Arbor is the most effective way to distill your idea into an actionable roadmap that your team can use to define and build out your product.'
+      get_started: 'To get started, click on the button below:'
+      create_account: 'Create Account'
+      view_project: 'View Project'
+      thanks: 'Thanks!'
+      arbor: '- Arbor Team'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Railsroot::Application.routes.draw do
-  devise_for :users
   root to: 'projects#index'
 
   resources :projects,  shallow: true, except: [:destroy] do
@@ -14,5 +13,6 @@ Railsroot::Application.routes.draw do
     resources :goals, only: [:create]
   end
 
+  devise_for :users, controllers: { registrations: 'registrations' }
   resources :user_stories, only: [:edit, :update, :destroy]
 end

--- a/db/migrate/20150819184539_create_invites.rb
+++ b/db/migrate/20150819184539_create_invites.rb
@@ -1,0 +1,10 @@
+class CreateInvites < ActiveRecord::Migration
+  def change
+    create_table :invites do |t|
+      t.string :email
+      t.references :project, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,15 @@ ActiveRecord::Schema.define(version: 20150821121912) do
     t.datetime "updated_at"
   end
 
+  create_table "invites", force: :cascade do |t|
+    t.string   "email"
+    t.integer  "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "invites", ["project_id"], name: "index_invites_on_project_id", using: :btree
+
   create_table "members_projects", force: :cascade do |t|
     t.integer "member_id",  null: false
     t.integer "project_id", null: false
@@ -115,4 +124,5 @@ ActiveRecord::Schema.define(version: 20150821121912) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "invites", "projects"
 end

--- a/spec/factories/invites.rb
+++ b/spec/factories/invites.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :invite do
+    email    { Faker::Internet.email }
+    project  { create :project }
+  end
+end

--- a/spec/features/user/sign_up_spec.rb
+++ b/spec/features/user/sign_up_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature 'Sign up' do
+  context 'for a user with invites' do
+    let!(:project)  { create :project }
+    let!(:invite)   { create :invite, email: 'testing@test.com', project: project}
+
+    def create_user
+      visit new_user_registration_path
+      within '#signup' do
+        find('#user_full_name').set('Name')
+        find('#user_email').set('testing@test.com')
+        find('#user_password').set('11111111')
+        find('#user_password_confirmation').set('11111111')
+        click_button('Sign up')
+      end
+    end
+
+    scenario 'should delete the invite' do
+      count_before = Invite.count
+      create_user
+      count_after = Invite.count
+      expect(count_after).to eq(count_before - 1)
+    end
+
+    scenario 'should add user as member of the invite project' do
+      create_user
+      user = User.find_by(email:'testing@test.com')
+      expect(user.projects.count).to eq(1)
+      expect(user.projects.first.name).to eq(project.name)
+    end
+  end
+end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Invite do
+  let(:invite) { create :invite }
+
+  it { should validate_presence_of :email }
+  it { should validate_presence_of :project }
+  it { should belong_to :project }
+end

--- a/spec/services/project_member_services_spec.rb
+++ b/spec/services/project_member_services_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+feature 'invite members' do
+  let(:user)    { sign_in create :user }
+  let(:project) { create :project, owner: user, members: [user] }
+
+  context 'with both non users and users' do
+    let(:another_user)   { create :user }
+    let(:emails)         { ['email1@email.com', 'email2@email.com', another_user.email] }
+    let(:member_service) { ProjectMemberServices.new(project, user, emails) }
+
+    background do
+      member_service.invite_members
+    end
+
+    scenario 'should add invites for the non users' do
+      invites = Invite.all
+      expect(invites[0].email).to eq('email1@email.com')
+      expect(invites[0].project.name).to eq(project.name)
+      expect(invites[1].email).to eq('email2@email.com')
+      expect(invites[1].project.name).to eq(project.name)
+    end
+
+    scenario 'should not add invites for the users' do
+      expect(Invite.count).to eq(2)
+    end
+
+    scenario 'should add the users as project members' do
+      members = project.members
+      expect(members[0].id).to be(user.id)
+      expect(members[1].id).to be(another_user.id)
+    end
+
+    scenario 'should not add the non users to the project' do
+      expect(project.members.count).to be(2)
+    end
+  end
+end


### PR DESCRIPTION
Send a notification email to a user invited to collaborate on a new project.
Send an email inviting to create an account to non users invited to a new project.
Create invites when a non user is invited to join a project so that when he/she signs up it is already a collaborator on those projects.
Test feature.

https://trello.com/c/d23DLZwW/27-24-as-a-user-i-should-be-able-to-receive-an-email-invite-to-join-a-project-whenever-someone-adds-my-email-as-a-collaborator
