### PR TITLE
Fix variable error.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,7 +61,7 @@ class ProjectsController < ApplicationController
   end
 
   def assign_associations
-    @project.owner = current_user unless @project_owner
+    @project.owner ||= current_user
     ProjectMemberServices.new(@project, current_user, member_emails)
       .invite_members
   end

--- a/spec/features/project/edit_spec.rb
+++ b/spec/features/project/edit_spec.rb
@@ -75,6 +75,24 @@ feature 'Edit a project' do
     end
   end
 
+  context 'with a user that is not the project owner' do
+    let(:new_owner) { create :user }
+
+    background do
+      project.members << new_owner
+      project.update_attributes(owner: new_owner)
+      visit edit_project_path project
+    end
+
+    scenario 'should not modify the project owner when another user edits' do
+      click_button 'New Member'
+      fill_in 'member_0', with: 'email@email.com'
+      click_button 'Update Project'
+
+      expect{ project.reload }.not_to change{ project.owner }
+    end
+  end
+
   context 'with members', js: true do
     let(:member) { create :user, email: 'existing@test.com' }
 


### PR DESCRIPTION
Typo that made the project owner assignation happen every time the project was edited.
