### PR TITLE
Remove alert from sign in page.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,13 @@
 Railsroot::Application.routes.draw do
-  root to: 'projects#index'
+  devise_scope :user do
+    authenticated :user do
+      root to: 'projects#index', as: :authenticated_root
+    end
+
+    unauthenticated :user do
+      root to: 'devise/sessions#new'
+    end
+  end
 
   resources :projects,  shallow: true do
     resources :hypotheses, only: [:index, :create]

--- a/spec/features/user/log_in.rb
+++ b/spec/features/user/log_in.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'Sign in' do
+  context 'when a user is not logged in' do
+    scenario 'there is no alert message on landing page' do
+      visit root_url
+      expect(page).not_to have_content('You need to sign in or sign up before continuing.')
+    end
+
+    scenario 'there is an alert message for urls other than landing page' do
+      visit projects_path
+      expect(page).to have_content('You need to sign in or sign up before continuing.')
+    end
+  end
+end


### PR DESCRIPTION
Remove default alert box on sign in page. 
Make it appear only when trying to access another url unauthenticated.
Test.

https://trello.com/c/Ra5gOb0t/36-28-non-registered-users-shouldn-t-see-the-alert-box-when-they-first-enter-the-site
