### PR TITLE
Logging for all project related activities.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'jquery-turbolinks'
 gem 'jbuilder', '~> 1.2'
 gem 'nilify_blanks', '1.2.1'
 gem 'jquery-ui-rails', '5.0.5'
+gem 'public_activity'
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,11 @@ GEM
     powerpack (0.1.1)
     private_attr (1.1.0)
     procto (0.0.2)
+    public_activity (1.4.2)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -345,6 +350,7 @@ DEPENDENCIES
   passenger (= 5.0.15)
   pg
   poltergeist
+  public_activity
   rails (= 4.2.3)
   rails_12factor
   rails_best_practices

--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -49,5 +49,4 @@ $('#sidebar a').each(function() {
   }
 });
 
-
 $(document).ready(UTIL.init);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include PublicActivity::StoreController
+
   protect_from_forgery with: :exception
   before_action :authenticate_user!, :current_user_projects
   before_action :configure_permitted_parameters, if: :devise_controller?

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -8,6 +8,7 @@ class GoalsController < ApplicationController
     @goal.hypothesis = @hypothesis
 
     if @goal.save
+      @hypothesis.goals << @goal
       redirect_to project_hypotheses_path(@hypothesis.project)
     else
       @errors = @goal.errors.full_messages
@@ -30,7 +31,7 @@ class GoalsController < ApplicationController
   end
 
   def destroy
-    @goal.destroy
+    @hypothesis.goals.destroy(@goal)
 
     redirect_to project_hypotheses_path(@hypothesis.project)
   end

--- a/app/controllers/hypotheses_controller.rb
+++ b/app/controllers/hypotheses_controller.rb
@@ -13,6 +13,7 @@ class HypothesesController < ApplicationController
     @hypothesis.project = @project
 
     if @hypothesis.save
+      @project.hypotheses << @hypothesis
       redirect_to project_hypotheses_path(@project)
     else
       @hypothesis_types = HypothesisType.all
@@ -21,8 +22,7 @@ class HypothesesController < ApplicationController
   end
 
   def destroy
-    @hypothesis = @project.hypotheses.find(params[:id])
-    @hypothesis.destroy
+    @project.hypotheses.destroy(@hypothesis)
 
     redirect_to project_hypotheses_path(@project)
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,7 +62,9 @@ class ProjectsController < ApplicationController
   end
 
   def assign_associations
-    ProjectMemberServices.new(@project, current_user, member_emails)
-      .invite_members
+    @project.owner ||= current_user
+    ProjectMemberServices.new(
+      @project, current_user, member_emails
+    ).invite_members
   end
 end

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -1,5 +1,6 @@
 class UserStoriesController < ApplicationController
   before_action :load_user_story, only: [:update, :destroy, :edit]
+  before_action :set_hypothesis, only: [:create]
   before_action :check_edit_permission,
     only: [:create, :destroy, :update, :update_order, :index, :edit]
 
@@ -20,6 +21,7 @@ class UserStoriesController < ApplicationController
     @user_story.project = @project
 
     if @user_story.save
+      update_associations
       redirect_to :back
     else
       @errors = @user_story.errors.full_messages
@@ -38,7 +40,7 @@ class UserStoriesController < ApplicationController
   end
 
   def destroy
-    @user_story.destroy
+    @project.user_stories.destroy(@user_story)
 
     redirect_to project_hypotheses_path(@project)
   end
@@ -58,6 +60,11 @@ class UserStoriesController < ApplicationController
                  :members,
                  :hypotheses])
       .find(params[:project_id])
+  end
+
+  def set_hypothesis
+    hypothesis_id = user_story_params[:hypothesis_id]
+    @hypothesis = Hypothesis.find(hypothesis_id) if hypothesis_id
   end
 
   def check_edit_permission
@@ -84,5 +91,10 @@ class UserStoriesController < ApplicationController
 
   def update_order_params
     params.require(:hypotheses)
+  end
+
+  def update_associations
+    @project.user_stories << @user_story
+    @hypothesis.user_stories << @user_story if @hypothesis
   end
 end

--- a/app/models/concerns/association_loggable.rb
+++ b/app/models/concerns/association_loggable.rb
@@ -1,0 +1,40 @@
+module AssociationLoggable
+  extend ActiveSupport::Concern
+
+  included do
+    include WithoutAssociationLoggable
+
+    private
+
+    def self.association_callback_fields
+      fields = reflect_on_all_associations(:has_many).map(&:name).map(&:to_s)
+      fields -= ['activities']
+      fields.select! do |field|
+        single_column_association?(field) || !through_association?(field)
+      end
+
+      fields
+    end
+
+    def self.single_column_association?(field)
+      !field.include? '_'
+    end
+
+    def self.through_association?(field)
+      field.split('_').all? do |column|
+        column.pluralize == column
+      end
+    end
+
+    %w(add remove).each do |action|
+      association_callback_fields.each do |assoc_model|
+        send(
+          "after_#{action}_for_#{assoc_model}".to_sym
+        ) << lambda do |_klass, object, assoc_object|
+          key = "#{action}_#{assoc_model.singularize}"
+          object.create_activity key, recipient: assoc_object if object.save
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/without_association_loggable.rb
+++ b/app/models/concerns/without_association_loggable.rb
@@ -1,0 +1,12 @@
+module WithoutAssociationLoggable
+  extend ActiveSupport::Concern
+
+  included do
+    include PublicActivity::Model
+
+    tracked(
+      owner: proc { |controller, _model| controller.current_user },
+      on:    { update: proc { |model, _controller| model.changed? } }
+    )
+  end
+end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,4 +1,6 @@
 class Goal < ActiveRecord::Base
+  include WithoutAssociationLoggable
+
   validates_presence_of :title
 
   belongs_to :hypothesis

--- a/app/models/hypothesis.rb
+++ b/app/models/hypothesis.rb
@@ -11,6 +11,8 @@ class Hypothesis < ActiveRecord::Base
 
   delegate :description, :code, to: :hypothesis_type, prefix: true
 
+  include AssociationLoggable
+
   def self.new_order(hypothesis_hash)
     hypothesis = Hypothesis.find(hypothesis_hash[:id])
     hypothesis.order = hypothesis_hash[:order]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,12 +3,14 @@ class Project < ActiveRecord::Base
   validates_uniqueness_of :name
 
   belongs_to :owner, class_name: User
-  has_many :members_projects, class_name: MembersProject
-  has_many :members, class_name: User, through: :members_projects
+  has_one :canvas, dependent: :destroy
   has_many :hypotheses, dependent: :destroy
   has_many :invites, dependent: :destroy
-  has_one :canvas, dependent: :destroy
   has_many :user_stories, dependent: :destroy
+  has_many :members_projects, class_name: MembersProject
+  has_many :members, class_name: User, through: :members_projects
+
+  include AssociationLoggable
 
   def as_json
     super(only: [:name])

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -1,4 +1,6 @@
 class UserStory < ActiveRecord::Base
+  include WithoutAssociationLoggable
+
   PRIORITIES = %w(m s c w)
 
   validates_presence_of :role, :action, :result

--- a/app/services/project_member_services.rb
+++ b/app/services/project_member_services.rb
@@ -38,7 +38,7 @@ class ProjectMemberServices
   end
 
   def invite_new_user(data)
-    Invite.create(email: data[:email], project: @project)
+    @project.invites << Invite.create(email: data[:email])
     InviteMailer.project_invite_email(data, true).deliver_now
   end
 end

--- a/app/views/goals/_index.haml
+++ b/app/views/goals/_index.haml
@@ -7,4 +7,4 @@
     %tr
       %td= goal.title
       %td= link_to t('edit'), edit_goal_path(goal)
-      %td= link_to t('delete'), goal_path(goal), method: :delete
+      %td= link_to t('labs.goals.delete'), goal_path(goal), method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
       title: "Title"
       enter_title: "Enter Title"
       export: "Export"
+      delete: "Delete Goal"
   create_project:
     title: "Start creating your project"
     project_button: "Create new project"

--- a/db/migrate/20150828113054_create_activities.rb
+++ b/db/migrate/20150828113054_create_activities.rb
@@ -1,0 +1,23 @@
+# Migration responsible for creating a table with activities
+class CreateActivities < ActiveRecord::Migration
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, :polymorphic => true
+      t.belongs_to :owner, :polymorphic => true
+      t.string  :key
+      t.text    :parameters
+      t.belongs_to :recipient, :polymorphic => true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+  end
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150824192708) do
+ActiveRecord::Schema.define(version: 20150828113054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.integer  "trackable_id"
+    t.string   "trackable_type"
+    t.integer  "owner_id"
+    t.string   "owner_type"
+    t.string   "key"
+    t.text     "parameters"
+    t.integer  "recipient_id"
+    t.string   "recipient_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type", using: :btree
+  add_index "activities", ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type", using: :btree
+  add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type", using: :btree
 
   create_table "canvas", force: :cascade do |t|
     t.text     "problems"

--- a/spec/controllers/user_stories_controller_spec.rb
+++ b/spec/controllers/user_stories_controller_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe UserStoriesController do
         first_story_updated, second_story_updated, third_story_updated =
           get_reordered(@first_story, @second_story, @third_story)
 
-        expect(first_story_updated.order).to be(2)
-        expect(second_story_updated.order).to be(3)
-        expect(third_story_updated.order).to be(1)
+        expect(first_story_updated.order).to eq 2
+        expect(second_story_updated.order).to eq 3
+        expect(third_story_updated.order).to eq 1
       end
     end
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :project do
     sequence(:name) { |n| Faker::Lorem.word + "(#{n})" }
-    owner { create :user }
-    members { [owner] }
-    hypotheses { [] }
+    owner           { create :user }
+    members         { [owner] }
+    hypotheses      { [] }
   end
 end

--- a/spec/features/project/goal/goal_log_spec.rb
+++ b/spec/features/project/goal/goal_log_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+feature 'Log goal activity' do
+  it_behaves_like 'a loggable entity' do
+    let(:entity)       { create :goal }
+    let(:update_field) { :title }
+  end
+end

--- a/spec/features/project/hypothesis/hypothesis_log_spec.rb
+++ b/spec/features/project/hypothesis/hypothesis_log_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+feature 'Log hypothesis activity' do
+  it_behaves_like 'a loggable entity' do
+    let(:entity)       { create :hypothesis }
+    let(:update_field) { :description }
+  end
+end

--- a/spec/features/project/lab_log_spec.rb
+++ b/spec/features/project/lab_log_spec.rb
@@ -1,0 +1,195 @@
+require 'spec_helper'
+
+feature 'Log lab activity' do
+  let!(:user) { create :user }
+
+  background do
+    sign_in user
+  end
+
+  context 'for creating projects' do
+    scenario 'should log project creation' do
+      PublicActivity.with_tracking do
+        within '.content-general' do
+          click_link 'Create new project'
+        end
+        fill_in 'project_name', with: 'Test Project'
+        click_button 'Save Project'
+      end
+
+      project_activities = Project.first.activities
+      expect(project_activities.count).to eq 2
+      expect(project_activities.first.key).to eq 'project.create'
+    end
+
+    scenario 'should log adding the owner as a member' do
+      PublicActivity.with_tracking do
+        within '.content-general' do
+          click_link 'Create new project'
+        end
+        fill_in 'project_name', with: 'Test Project'
+        click_button 'Save Project'
+      end
+
+      expect(Project.first.activities.second.key).to eq 'project.add_member'
+    end
+
+    scenario 'should not create logs when the save fails' do
+      PublicActivity.with_tracking do
+        within '.content-general' do
+          click_link 'Create new project'
+        end
+        click_button 'Save Project'
+      end
+
+      expect(PublicActivity::Activity.all).to be_empty
+    end
+  end
+
+  context 'for an existing project' do
+    let!(:project)         { create :project, owner: user }
+
+    context 'hypotheses' do
+      let!(:hypothesis_type) { create :hypothesis_type }
+      let(:hypothesis)       { build :hypothesis }
+
+      background do
+        visit project_path project
+      end
+
+      scenario 'should log adding hypotheses' do
+        click_link project.name
+
+        PublicActivity.with_tracking do
+          within '.hypothesis-new' do
+            fill_in 'hypothesis_description', with: hypothesis.description
+            find(
+              '#hypothesis_hypothesis_type_id'
+            ).select(hypothesis_type.description)
+            click_button 'Save'
+          end
+        end
+
+        last_actvity = PublicActivity::Activity.last
+        expect(last_actvity.key).to eq 'project.add_hypothesis'
+      end
+
+      scenario 'should log removing hypotheses' do
+        create :hypothesis, project: project
+        click_link project.name
+
+        PublicActivity.with_tracking do
+          within '.delete-hypothesis' do
+            find('.trash-btn').click
+          end
+        end
+
+        last_actvity = PublicActivity::Activity.last
+        expect(last_actvity.key).to eq 'project.remove_hypothesis'
+      end
+    end
+
+    context 'invites' do
+      let(:invitee) { build :user }
+
+      background do
+        visit edit_project_path project
+      end
+
+      scenario 'should log inviting members', js: true do
+        click_button 'New Member'
+        fill_in 'member_0', with: invitee.email
+
+        PublicActivity.with_tracking do
+          click_button 'Update Project'
+        end
+
+        last_actvity = PublicActivity::Activity.last
+        expect(last_actvity.key).to eq 'project.add_invite'
+      end
+    end
+
+    context 'epics' do
+      let!(:hypothesis) { create :hypothesis, project: project }
+      let(:epic)        { build :epic }
+
+      background do
+        visit project_path project
+      end
+
+      scenario 'should log adding epics' do
+        click_link project.name
+
+        within 'form.new_user_story' do
+          fill_in :user_story_role, with: epic.role
+          fill_in :user_story_action, with: epic.action
+          fill_in :user_story_result, with: epic.result
+
+          PublicActivity.with_tracking do
+            click_button 'Save'
+          end
+        end
+
+        activities = PublicActivity::Activity.all
+        expect(activities.first.key).to eq 'user_story.create'
+        expect(activities.second.key).to eq 'project.add_user_story'
+        expect(activities.third.key).to eq 'hypothesis.add_user_story'
+      end
+
+      scenario 'should log removing epics' do
+        create :epic, project: hypothesis.project, hypothesis: hypothesis
+        click_link project.name
+
+        PublicActivity.with_tracking do
+          within '.user-story' do
+            find('a.trash-btn').click
+          end
+        end
+
+        activities = PublicActivity::Activity.all
+        expect(activities.first.key).to eq 'user_story.destroy'
+        expect(activities.second.key).to eq 'project.remove_user_story'
+      end
+    end
+
+    context 'goals' do
+      let!(:hypothesis) { create :hypothesis, project: project }
+      let(:goal)        { build :goal }
+
+      background do
+        visit project_path project
+      end
+
+      scenario 'should log adding goals' do
+        click_link project.name
+
+        within '.new-goal' do
+          fill_in :goal_title, with: goal.title
+          PublicActivity.with_tracking do
+            click_button 'Save'
+          end
+        end
+
+        activities = PublicActivity::Activity.all
+        expect(activities.first.key).to eq 'goal.create'
+        expect(activities.second.key).to eq 'hypothesis.add_goal'
+      end
+
+      scenario 'should log removing goals' do
+        create :goal, hypothesis: hypothesis
+
+        click_link project.name
+
+        within '.goals' do
+          PublicActivity.with_tracking do
+            click_link 'Delete Goal'
+          end
+        end
+
+        activities = PublicActivity::Activity.all
+        expect(activities.first.key).to eq 'goal.destroy'
+        expect(activities.second.key).to eq 'hypothesis.remove_goal'
+      end
+    end
+  end
+end

--- a/spec/features/project/project_log_spec.rb
+++ b/spec/features/project/project_log_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+feature 'Log project activity' do
+  it_behaves_like 'a loggable entity' do
+    let(:entity)       { create :project }
+    let(:update_field) { :name }
+  end
+end

--- a/spec/features/project/user_story/edit_spec.rb
+++ b/spec/features/project/user_story/edit_spec.rb
@@ -28,13 +28,13 @@ feature 'Edit an epic' do
     end
   end
 
-  scenario 'should be able to edit an epic on lab section', js: true do
+  scenario 'should be able to edit an epic on lab section' do
     visit project_hypotheses_path project
     within 'form.edit_user_story' do
       fill_in 'user_story_role', with: changed_epic.role
       fill_in 'user_story_action', with: changed_epic.action
-      fill_in 'user_story_result', with: "#{changed_epic.result}"
-      find('.user-story-submit', visible: false).trigger('click')
+      fill_in 'user_story_result', with: changed_epic.result
+      click_button 'Save'
     end
 
     visit project_hypotheses_path project
@@ -63,7 +63,7 @@ feature 'Edit an epic' do
     within 'form.edit_user_story' do
       fill_in 'user_story_role', with: changed_epic.role
       fill_in 'user_story_action', with: changed_epic.action
-      fill_in 'user_story_result', with: "#{changed_epic.result}"
+      fill_in 'user_story_result', with: changed_epic.result
       find('.user-story-submit', visible: false).trigger('click')
     end
 
@@ -73,8 +73,8 @@ feature 'Edit an epic' do
       within 'form.edit_user_story' do
         field_id = "#user_story_#{field}"
         field_value = page.find(field_id).value
-        expect(field_value).to have_text changed_epic.send(field)
-        expect(field_value).not_to have_content epic.send(field)
+        expect(field_value).to have_text changed_epic.try(field)
+        expect(field_value).not_to have_content epic.try(field)
       end
     end
   end

--- a/spec/features/project/user_story/user_story_log_spec.rb
+++ b/spec/features/project/user_story/user_story_log_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+feature 'Log user_story activity' do
+  it_behaves_like 'a loggable entity' do
+    let(:entity)       { create :user_story }
+    let(:update_field) { :role }
+  end
+end

--- a/spec/models/hypothesis_spec.rb
+++ b/spec/models/hypothesis_spec.rb
@@ -1,13 +1,9 @@
 require 'spec_helper'
 
-def add_hypothesis(project, quantity)
-  hypotheses = []
-  quantity.times { hypotheses.push(create :hypothesis, { project: project }) }
-  hypotheses
-end
-
 describe Hypothesis do
   let(:hypothesis) { create :hypothesis }
+  let(:project)    { create :project }
+  subject          { hypothesis }
 
   it { should validate_presence_of :description }
   it { should validate_presence_of :project }
@@ -16,9 +12,7 @@ describe Hypothesis do
   it { should belong_to :hypothesis_type }
 
   it 'must increase hypothesis order' do
-    project = create :project
-
-    hypotheses = add_hypothesis(project, 10)
+    hypotheses = create_list :hypothesis, 3, project: project
     hypotheses.each_with_index do |hypothesis, index|
       expect(hypothesis.order).to be(index + 1)
     end

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -1,20 +1,10 @@
 require 'spec_helper'
 
-def add_user_story(hypothesis, quantity)
-  user_stories = []
-
-  quantity.times do
-    user_stories.push(create :user_story, {hypothesis: hypothesis})
-  end
-
-  user_stories
-end
-
 RSpec.describe UserStory do
-  let!(:project)     { create :project }
-  let!(:hypothesis)  { create :hypothesis, project: project}
-  let!(:user_story)  { create :user_story, hypothesis: hypothesis }
-  subject            { user_story }
+  let(:project)     { create :project }
+  let(:hypothesis)  { create :hypothesis, project: project}
+  let(:user_story)  { create :user_story, hypothesis: hypothesis }
+  subject           { user_story }
 
   it { should validate_presence_of :role }
   it { should validate_presence_of :action }
@@ -24,7 +14,8 @@ RSpec.describe UserStory do
 
   it 'must increase user stories order' do
     hypothesis_ordered = create :hypothesis, project: project
-    user_stories = add_user_story(hypothesis_ordered, 3)
+
+    user_stories = create_list :user_story, 3, hypothesis: hypothesis
     user_stories.each_with_index do |user_story, index|
       expect(user_story.order).to be(index + 1)
     end

--- a/spec/services/hypothesis_services_spec.rb
+++ b/spec/services/hypothesis_services_spec.rb
@@ -22,9 +22,9 @@ feature 'Reorder user stories' do
     first_story_updated, second_story_updated, third_story_updated =
       get_reordered(@first_story, @second_story, @third_story)
 
-    expect(first_story_updated.order).to be(2)
-    expect(second_story_updated.order).to be(3)
-    expect(third_story_updated.order).to be(1)
+    expect(first_story_updated.order).to eq 2
+    expect(second_story_updated.order).to eq 3
+    expect(third_story_updated.order).to eq 1
   end
 
   scenario 'should reorder user stories on hypothesis' do
@@ -42,11 +42,11 @@ feature 'Reorder user stories' do
     first_story_updated, second_story_updated, third_story_updated =
       get_reordered(@first_story, @second_story, @third_story)
 
-    expect(first_story_updated.order).to be(2)
-    expect(first_story_updated.hypothesis_id).to be(hypothesis.id)
-    expect(second_story_updated.order).to be(1)
-    expect(second_story_updated.hypothesis_id).to be(hypothesis.id)
-    expect(third_story_updated.order).to be(1)
-    expect(third_story_updated.hypothesis_id).to be(second_hypothesis.id)
+    expect(first_story_updated.order).to eq 2
+    expect(first_story_updated.hypothesis_id).to eq hypothesis.id
+    expect(second_story_updated.order).to eq 1
+    expect(second_story_updated.hypothesis_id).to eq hypothesis.id
+    expect(third_story_updated.order).to eq 1
+    expect(third_story_updated.hypothesis_id).to eq second_hypothesis.id
   end
 end

--- a/spec/services/project_member_services_spec.rb
+++ b/spec/services/project_member_services_spec.rb
@@ -31,7 +31,7 @@ feature 'invite members' do
     end
 
     scenario 'should not add the non users to the project' do
-      expect(project.members.count).to be(2)
+      expect(project.members.count).to eq 2
     end
   end
 end

--- a/spec/services/project_services_spec.rb
+++ b/spec/services/project_services_spec.rb
@@ -30,7 +30,7 @@ feature 'Reorder hypothesis inside' do
 
     updated_first_hypothesis = Hypothesis.find(first_hypothesis.id)
     updated_second_hypothesis = Hypothesis.find(second_hypothesis.id)
-    expect(updated_first_hypothesis.order).to be(2)
-    expect(updated_second_hypothesis.order).to be(1)
+    expect(updated_first_hypothesis.order).to eq 2
+    expect(updated_second_hypothesis.order).to eq 1
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,10 +6,6 @@ Spork.prefork do
   ENV['FROM_EMAIL_ADDRESS'] = 'no-reply@getarbor.io'
   ENV['MAXIMUM_MEMBER_COUNT'] = '16'
 
-
-
-
-
   require File.expand_path('../../config/environment', __FILE__)
   require 'rspec/rails'
 
@@ -17,6 +13,9 @@ Spork.prefork do
   require 'capybara/rails'
   require 'capybara/poltergeist'
   require 'factory_girl_rails'
+  require 'public_activity/testing'
+
+  PublicActivity.enabled = false
 
   class ActiveRecord::Base
     mattr_accessor :shared_connection

--- a/spec/support/shared_examples/log_crud_actions.rb
+++ b/spec/support/shared_examples/log_crud_actions.rb
@@ -1,0 +1,51 @@
+RSpec.shared_examples 'a loggable entity' do
+  feature 'Log entity activity' do
+    let!(:user)      { create :user }
+    let(:entity_key) { entity.class.table_name.singularize }
+
+    background do
+      sign_in user
+    end
+
+    scenario 'should log entity creation' do
+      PublicActivity.with_tracking do
+        entity
+      end
+
+      activity_keys = PublicActivity::Activity.all.pluck(:key)
+      expect(activity_keys).to include "#{entity_key}.create"
+    end
+
+    scenario 'should log entity deletion' do
+      entity
+      PublicActivity.with_tracking do
+        entity.destroy
+      end
+
+      activities = PublicActivity::Activity.all
+      expect(activities.count).to eq 1
+      expect(activities.first.key).to eq "#{entity_key}.destroy"
+    end
+
+    scenario 'should log entity update' do
+      entity
+      PublicActivity.with_tracking do
+        entity.update_attribute(update_field, 'new_value')
+      end
+
+      activities = PublicActivity::Activity.all
+      expect(activities.count).to eq 1
+      expect(activities.first.key).to eq "#{entity_key}.update"
+    end
+
+    scenario 'should not log entity update if the data does not change' do
+      entity
+      PublicActivity.with_tracking do
+        entity.update_attribute(update_field, entity.try(update_field))
+      end
+
+      activities = PublicActivity::Activity.all
+      expect(activities).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Te4attb0/21-21-lab-as-a-user-i-must-be-able-to-see-a-change-log-of-all-activity-and-by-whom

Setup of PublicActivity gem to dynamically track all entities associated with projects.

Fixed bug that prevented the projects controller from creating hypotheses related logs.

Added tests for logging project creation.

Fixed tests for logging adding/removing hypotheses.

Added all project related association logging.

Tested whole logging functionality.

Made association callbacks more dynamic and fixed tests.

Fixed failing test caused by rebase.

Rebased from master and fixed errors cause by rebase.
