### PR TITLE
Bug/fix model uniqueness

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,9 +34,10 @@ class ProjectsController < ApplicationController
 
   def create
     @project = Project.new(project_params)
-    assign_associations
+    @project.owner = current_user
 
     if @project.save
+      assign_associations
       redirect_to projects_path
     else
       @errors = @project.errors.full_messages
@@ -56,12 +57,11 @@ class ProjectsController < ApplicationController
 
   def member_emails
     params[:project].select do |id, email|
-      email if id.starts_with?('member')
-    end.values.reject(&:blank?)
+      email if id.starts_with?('member') && email != current_user.email
+    end.values.reject(&:blank?).uniq
   end
 
   def assign_associations
-    @project.owner ||= current_user
     ProjectMemberServices.new(@project, current_user, member_emails)
       .invite_members
   end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,6 +1,6 @@
 class Invite < ActiveRecord::Base
-  validates_presence_of :email
-  validates_presence_of :project
+  validates_presence_of :email, :project
+  validates_uniqueness_of :email, scope: :project_id
 
   belongs_to :project
 end

--- a/spec/features/project/create_spec.rb
+++ b/spec/features/project/create_spec.rb
@@ -34,6 +34,17 @@ feature 'Create a new project' do
     expect(Project.first.name).to eq 'Test Project'
   end
 
+  scenario 'should not create invites when no name is set', js: true do
+    within '.content-general' do
+      click_link 'Create new project'
+    end
+    click_button 'New Member'
+    fill_in 'member_0', with: 'test@test.com'
+    click_button 'Save Project'
+
+    expect(Invite.count).to eq(0)
+  end
+
   context 'with members provided', js: true do
     before :each do
       visit new_project_path
@@ -55,6 +66,29 @@ feature 'Create a new project' do
 
       expect(Project.first.members.count).to eq 1
       expect(Project.first.members).to include user
+    end
+
+    scenario 'should ignore duplicate current user' do
+      click_button 'New Member'
+      click_button 'New Member'
+
+      fill_in 'member_0', with: user.email
+      fill_in 'member_1', with: user.email
+
+       click_button 'Save Project'
+      expect(Project.first.members.count).to eq 1
+    end
+
+    scenario 'should ignore duplicate emails' do
+      additional_member = create :user, email: 'existing@test.com'
+
+      click_button 'New Member'
+      click_button 'New Member'
+
+      fill_in 'member_0', with: additional_member.email
+      fill_in 'member_1', with: additional_member.email
+       click_button 'Save Project'
+      expect(Project.first.members.count).to eq 2
     end
 
     scenario 'should add existing users to the project' do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -1,9 +1,27 @@
 require 'spec_helper'
 
 describe Invite do
-  let(:invite) { create :invite }
+  let(:project) { create :project }
+  let!(:invite) { create :invite, email: 'test@test.com', project: project }
 
   it { should validate_presence_of :email }
   it { should validate_presence_of :project }
+  it { should validate_uniqueness_of(:email).scoped_to(:project_id)}
   it { should belong_to :project }
+
+  it 'must not accept duplicate invites' do
+    expect{ create :invite, email: 'test@test.com', project: project }
+      .to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'must accept same email and different project' do
+    project2 = create :project
+    expect{ create :invite, email: 'test@test.com', project: project2 }
+      .not_to raise_error
+  end
+
+  it 'must accept same project and different email' do
+    expect{ create :invite, email: 'test2@test2.com', project: project }
+      .not_to raise_error
+  end
 end


### PR DESCRIPTION
- Fix uniqueness on Invite model to not allow duplicate entries on the Invite table.
- Consider the case in which a user creating the project adds itself to the list.
- Consider the case  in which a user creating the project adds duplicate emails.
- Fix code to avoid creating invites when a user creating a project adds members and submits with no project name.
- Test.

https://trello.com/c/qKefkAL4/47-bug-when-creating-a-project-with-members-set-but-no-name-invites-are-being-created-even-though-the-project-creation-fails
