### PR TITLE
Move sendgrid configuration.

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,13 +3,3 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Railsroot::Application.initialize!
-
-ActionMailer::Base.smtp_settings = {
-  address:              'smtp.sendgrid.net',
-  port:                 '587',
-  authentication:       :plain,
-  user_name:            ENV['SENDGRID_USERNAME'],
-  password:             ENV['SENDGRID_PASSWORD'],
-  domain:               'heroku.com',
-  enable_starttls_auto: true
-}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,3 +15,13 @@ Railsroot::Application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
 end
+
+ActionMailer::Base.smtp_settings = {
+  address:              'smtp.sendgrid.net',
+  port:                 '587',
+  authentication:       :plain,
+  user_name:            ENV['SENDGRID_USERNAME'],
+  password:             ENV['SENDGRID_PASSWORD'],
+  domain:               'heroku.com',
+  enable_starttls_auto: true
+}


### PR DESCRIPTION
The Sendgrid configuration located in environment.rb prevents the mailer configuration on other environments rather than production to have effect. The solution is adding this code to the production environment only.
