### PR TITLE
Add story number

### DIFF
--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -42,7 +42,7 @@ class UserStoriesController < ApplicationController
   def destroy
     @project.user_stories.destroy(@user_story)
 
-    redirect_to project_hypotheses_path(@project)
+    redirect_to :back
   end
 
   def update_order

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -5,8 +5,10 @@ class UserStory < ActiveRecord::Base
 
   validates_presence_of :role, :action, :result
   validates_uniqueness_of :order, scope: :hypothesis_id, allow_nil: true
+  validates_uniqueness_of :story_number, scope: :project_id
   validates_inclusion_of :priority, in: PRIORITIES
   before_create :order_in_hypotheses
+  before_create :assign_story_number
 
   belongs_to :hypothesis
   belongs_to :project
@@ -25,5 +27,9 @@ class UserStory < ActiveRecord::Base
   def order_in_hypotheses
     return unless hypothesis
     self.order = hypothesis.user_stories.maximum(:order).to_i + 1
+  end
+
+  def assign_story_number
+    self.story_number = project.user_stories.maximum(:story_number).to_i + 1
   end
 end

--- a/app/views/user_stories/index.haml
+++ b/app/views/user_stories/index.haml
@@ -7,6 +7,8 @@
       %ul
         %li.user-story{ data: { user_id: user_story.id,
         url: edit_user_story_path(user_story) } }
+          .story-number
+            = "##{user_story.story_number}"
           = t('backlog.user_stories.role_prefix') + |
           ' ' + user_story.role + ' ' +             |
           t('backlog.user_stories.action_prefix') + |

--- a/db/migrate/20150902142305_add_story_number_to_user_story.rb
+++ b/db/migrate/20150902142305_add_story_number_to_user_story.rb
@@ -1,0 +1,6 @@
+class AddStoryNumberToUserStory < ActiveRecord::Migration
+  def change
+    add_column :user_stories, :story_number, :integer
+    add_index :user_stories, :story_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150828113054) do
+ActiveRecord::Schema.define(version: 20150902142305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,10 +117,12 @@ ActiveRecord::Schema.define(version: 20150828113054) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "order"
+    t.integer  "story_number"
   end
 
   add_index "user_stories", ["hypothesis_id"], name: "index_user_stories_on_hypothesis_id", using: :btree
   add_index "user_stories", ["project_id"], name: "index_user_stories_on_project_id", using: :btree
+  add_index "user_stories", ["story_number"], name: "index_user_stories_on_story_number", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "",    null: false

--- a/spec/features/project/user_story/list_epics_spec.rb
+++ b/spec/features/project/user_story/list_epics_spec.rb
@@ -22,7 +22,6 @@ feature 'List epics' do
       action:     'administrate',
       result:     'do work'
     )
-
     sign_in user
   end
 
@@ -44,6 +43,7 @@ feature 'List epics' do
         expect(page).to have_text epic.role
         expect(page).to have_text epic.action
         expect(page).to have_text epic.result
+        expect(page).to have_text epic.story_number
       end
     end
   end

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe UserStory do
   it { should validate_presence_of :result }
   it { should validate_inclusion_of(:priority).in_array %w(m s c w) }
   it { should belong_to(:project) }
+  it { should validate_uniqueness_of(:story_number).scoped_to(:project_id)}
 
   it 'must increase user stories order' do
     hypothesis_ordered = create :hypothesis, project: project
@@ -18,6 +19,14 @@ RSpec.describe UserStory do
     user_stories = create_list :user_story, 3, hypothesis: hypothesis
     user_stories.each_with_index do |user_story, index|
       expect(user_story.order).to be(index + 1)
+    end
+  end
+
+  it 'must increment user story number' do
+    test_project = create :project
+    user_stories = create_list :user_story, 3, project: test_project
+    user_stories.each_with_index do |user_story, index|
+      expect(user_story.story_number).to eq(index + 1)
     end
   end
 end

--- a/spec/services/hypothesis_services_spec.rb
+++ b/spec/services/hypothesis_services_spec.rb
@@ -27,7 +27,7 @@ feature 'Reorder user stories' do
     expect(third_story_updated.order).to eq 1
   end
 
-  scenario 'should reorder user stories on hypothesis' do
+  scenario 'should reorder user stories on different hypothesis' do
     second_hypothesis = create :hypothesis, project: project
     first_hypothesis_stories = { '0' => {'id' => @first_story.id, 'order' => 2},
                                  '1' => {'id' => @second_story.id, 'order' => 1} }


### PR DESCRIPTION
Add a unique (per Project) story number to User Stories on Backlog.
Test.

https://trello.com/c/xOLgX3Ek/44-31-backlog-as-a-user-i-must-be-able-to-see-the-stories-number-when-viewing-them-in-the-backlog-from-lab
