### PR TITLE
Fixed double increment on story number.

### DIFF
--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -96,7 +96,6 @@ class UserStoriesController < ApplicationController
 
   def update_associations
     @project.user_stories << @user_story
-    @project.update_attribute :next_story_number, @project.next_story_number + 1
     @hypothesis.user_stories << @user_story if @hypothesis
   end
 end


### PR DESCRIPTION
I updated the next story number on the associated project once in a model callback and once in the controller on successfully saving a story in the create action.
This removes the call from the controller.
