### PR TITLE
remove success mesage on sign in.

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -41,7 +41,7 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."
     sessions:
-      signed_in: "Signed in successfully."
+      signed_in: ""
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:

--- a/spec/features/user/log_in.rb
+++ b/spec/features/user/log_in.rb
@@ -12,4 +12,14 @@ feature 'Sign in' do
       expect(page).to have_content('You need to sign in or sign up before continuing.')
     end
   end
+
+  context 'when the user logs in' do
+    background do
+      sign_in create :user
+    end
+    
+    scenario 'should not show a success message' do
+      expect(page).not_to have_content('Signed in successfully.')
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/cOrbHb3b/65-bug-65-hide-you-have-signed-in-successfully-message-at-sign-in
