### PR TITLE
Feedback: Meta tags were not displayed on the landing page

### DIFF
--- a/app/views/layouts/guest.haml
+++ b/app/views/layouts/guest.haml
@@ -1,10 +1,11 @@
 !!!
 %html
   %head
-    %title Arbor
+    %title
+      = meta_title
+    %meta{ content: "#{meta_description}", name: 'description' }
     %meta{ charset: 'UTF-8' }
     %meta{ content: 'IE=edge,chrome=1', 'http-equiv' => 'X-UA-Compatible' }
-    %meta{ content: 'Math Lessons', name: 'description' }
     %meta{ content: 'True', name: 'HandheldFriendly' }
     %meta{ content: '320', name: 'MobileOptimized' }
     %meta{ content: 'width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0', name: 'viewport' }

--- a/spec/features/meta_tags/landing_page_spec.rb
+++ b/spec/features/meta_tags/landing_page_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+feature 'Meta tags on landing page' do
+  it_behaves_like 'a meta tagged page' do
+    let(:user) { nil }
+  end
+end

--- a/spec/features/meta_tags/project_page_spec.rb
+++ b/spec/features/meta_tags/project_page_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+feature 'Meta tags on project page' do
+  it_behaves_like 'a meta tagged page' do
+    let(:user) { create :user }
+  end
+end

--- a/spec/support/matchers/have_meta_matcher.rb
+++ b/spec/support/matchers/have_meta_matcher.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :have_meta do |name, expected|
+  match do |actual|
+    has_css?("meta[name='#{name}'][content='#{expected}']", visible: false)
+  end
+
+  failure_message do |actual|
+    actual = page.find "meta[name='#{name}']", visible: false
+    if actual
+      "expected that meta #{name} would have content='#{expected}' but was '#{actual[:content]}'"
+    else
+      "expected that meta #{name} would exist with content='#{expected}'"
+    end
+  end
+end

--- a/spec/support/shared_examples/meta_tagged_page.rb
+++ b/spec/support/shared_examples/meta_tagged_page.rb
@@ -1,0 +1,35 @@
+RSpec.shared_examples 'a meta tagged page' do
+  context 'without meta tags set' do
+    background do
+      ENV['META_TITLE'] = nil
+      ENV['META_DESCRIPTION'] = nil
+      sign_in user if user
+      visit '/'
+    end
+
+    scenario 'shows the meta title' do
+      expect(page).to have_title 'Arbor'
+    end
+
+    scenario 'shows the meta description' do
+      expect(page).to have_meta(:description, 'Add meta description')
+    end
+  end
+
+  context 'with meta tags set' do
+    background do
+      ENV['META_TITLE'] = 'Arbor v.2'
+      ENV['META_DESCRIPTION'] = 'Rootstrapping easily done'
+      sign_in user if user
+      visit '/'
+    end
+
+    scenario 'shows the meta title' do
+      expect(page).to have_title 'Arbor v.2'
+    end
+
+    scenario 'shows the meta description' do
+      expect(page).to have_meta(:description, 'Rootstrapping easily done')
+    end
+  end
+end


### PR DESCRIPTION
Display meta tags also on landing page. Provided tests for meta tags on landing and project pages.
https://trello.com/c/YsfpjIrt/101-101-change-meta-tags-of-math-lessons
