### PR TITLE
Story/110/keep user story focus

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,3 @@ DEPENDENCIES
   spork-rails
   thin
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.5

--- a/app/assets/javascripts/userStories/init.js
+++ b/app/assets/javascripts/userStories/init.js
@@ -19,14 +19,18 @@ ARBOR.user_stories.init = function() {
     return newOrder;
   }
 
+  function displayStoryForm(url) {
+    $.get(url, function(editForm) {
+      $userStoryForm.html('');
+      $userStoryForm.html(editForm);
+      bindEditForm();
+    });
+  }
+
   function bindUserStoriesEvents() {
     $userStoriesOnList.click(function() {
       var url = $(this).data('url');
-
-      $.get(url, function(editForm) {
-        $userStoryForm.html('');
-        $userStoryForm.html(editForm);
-      });
+      displayStoryForm(url);
     });
 
     $userStoriesList.sortable({
@@ -79,13 +83,39 @@ ARBOR.user_stories.init = function() {
       success: function (response) {
         if(response.success) {
           refreshBacklog();
-          $newUserStoryForm.trigger('reset');
+          editUrl = response.data.edit_url;
+          displayStoryForm(editUrl);
         }
       }
     });
-
     return false;
   });
+
+  function bindEditForm() {
+    $editForm = $('form.edit-story.edit_user_story');
+
+    $editForm.submit(function() {
+      var url       = $(this).attr('action'),
+          type      = $(this).attr('method'),
+          userStory = $(this).serialize();
+
+      hideBacklog();
+
+      $.ajax({
+        type: type,
+        url: url,
+        data: userStory,
+        success: function (response) {
+          if(response.success) {
+            refreshBacklog();
+            editUrl = response.data.edit_url
+            displayStoryForm(editUrl);
+          }
+        }
+      });
+      return false;
+    });
+  }
 };
 
 dynamicInput();
@@ -186,4 +216,3 @@ function dynamicInput() {
     });
   })($);
 };
-

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -25,17 +25,14 @@ class UserStoriesController < ApplicationController
 
   def update
     @user_story.update_attributes(user_story_params)
-    if @user_story.save
-      redirect_to :back
-    else
-      @errors = @user_story.errors.full_messages
-      render :edit, status: 400
-    end
+    @user_story_service = UserStoryService.new(@project)
+    response =
+      @user_story_service.update_user_story(@user_story)
+    render json: response
   end
 
   def destroy
     @project.user_stories.destroy(@user_story)
-
     redirect_to :back
   end
 

--- a/app/services/user_story_service.rb
+++ b/app/services/user_story_service.rb
@@ -1,8 +1,9 @@
 class UserStoryService
-  def initialize(project, hypothesis)
+  def initialize(project, hypothesis = nil)
     @common_response = CommonResponse.new(true, [])
     @project = project
     @hypothesis = hypothesis
+    @route_helper = Rails.application.routes.url_helpers
   end
 
   def new_user_story(user_story_params)
@@ -10,13 +11,32 @@ class UserStoryService
     update_associations(user_story)
 
     if user_story.save
-      @common_response.data[:user_story_id] = user_story.id
+      assign_common_response(user_story)
     else
       @common_response.success = false
       @common_response.errors += user_story.errors.full_messages
     end
-
     @common_response
+  end
+
+  def update_user_story(user_story)
+    if user_story.save
+      @common_response.data[:edit_url] =
+        @route_helper.edit_user_story_path(user_story)
+    else
+      @common_response.success = false
+      @common_response.errors += user_story.errors.full_messages
+    end
+    @common_response
+  end
+
+  private
+
+  def assign_common_response(user_story)
+    common_response_data = @common_response.data
+    common_response_data[:user_story_id] = user_story.id
+    common_response_data[:edit_url] =
+      @route_helper.edit_user_story_path(user_story)
   end
 
   def update_associations(user_story)

--- a/spec/controllers/user_stories_controller_spec.rb
+++ b/spec/controllers/user_stories_controller_spec.rb
@@ -1,15 +1,47 @@
 require 'spec_helper'
 
 RSpec.describe UserStoriesController do
-  describe 'POST create' do
-    let!(:user)        { create :user }
-    let!(:project)     { create :project, owner: user }
-    let!(:hypothesis)  { create :hypothesis, project: project }
+  let!(:user)        { create :user }
+  let!(:project)     { create :project, owner: user }
+  let!(:hypothesis)  { create :hypothesis, project: project }
 
-    before :each do
-      sign_in user
+  before :each do
+    sign_in user
+  end
+
+  describe 'POST update' do
+    let!(:user_story) {
+      create :user_story,
+      project: project,
+      role: 'user',
+      action: 'sign up',
+      result: 'i can browse the site',
+      estimated_points: '3',
+      priority: 'should',
+      epic: 'false'
+    }
+
+    it 'send a success response with the edit url' do
+      request.env['HTTP_REFERER'] = project_user_stories_path(project.id)
+      post :update, id: user_story.id, user_story: {
+          role: 'admin',
+          action: 'sign up',
+          result: 'i can browse the database',
+          estimated_points: '3',
+          priority: 'should',
+          epic: 'false'
+        }
+
+      expect(UserStory.count).to eq(1)
+      user_story = UserStory.last
+      hash_response = JSON.parse(response.body)
+
+      expect(hash_response['success']).to eq(true)
+      expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
     end
+  end
 
+  describe 'POST create' do
     it 'send a success response with user story id' do
       request.env['HTTP_REFERER'] = project_hypotheses_path(project.id)
       post :create, project_id: project.id, user_story: {

--- a/spec/services/user_story_service_spec.rb
+++ b/spec/services/user_story_service_spec.rb
@@ -1,4 +1,25 @@
 require 'spec_helper'
+
+feature 'update user story' do
+  let(:project)       { create :project }
+  let(:story_service) { UserStoryService.new(project) }
+  let(:user_story)    {
+    create :user_story,
+    role: 'User',
+    action: 'be able to reset my password',
+    result: 'so that I can recover my account',
+    estimated_points: 1,
+    priority: 'should',
+    epic: false
+  }
+
+  scenario 'should load the response' do
+    response = story_service.update_user_story(user_story)
+    expect(response.success).to eq(true)
+    expect(response.data[:edit_url]).to eq(edit_user_story_path(user_story))
+  end
+end
+
 feature 'create user story' do
   let(:project)           { create :project }
   let(:hypothesis)        { create :hypothesis, project: project }


### PR DESCRIPTION
https://trello.com/c/sa585CBu/127-127-keep-focus-of-selected-user-story-after-creating-or-editing-one

Feature:
After editing or creating a new user story on the backlog the focus remains on the user story.

Notes:
This feature has been discussed with Thalia and may be removed in the future if they decide it doesn't work from the UX point of view.
