### PR TITLE
Frontend/value prop bug

### DIFF
--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -5,9 +5,18 @@
 // HYPOTHESIS
 // --------------------------------------------------------
 .value-prop {
-  padding: rem-calc(20);
+  padding: rem-calc(20 0 0 20);
+  width: 80%;
 
-  .title-value-proposition { padding: 0; }
+  .title-value-proposition {
+    display: inline-block;
+    padding: 0;
+  }
+
+  .hollow-btn {
+    float: right;
+    width: auto;
+  }
 
   .hypotheses-value-proposition {
     display: none;

--- a/app/views/hypotheses/index.haml
+++ b/app/views/hypotheses/index.haml
@@ -20,8 +20,8 @@
       %li#trello_export_link
         = link_to t('trello.export'), '#'
 - if @project.canvas
-  .value-prop.row
-    .title-value-proposition.large-8.columns
+  .value-prop
+    .title-value-proposition
       %h2=@project.canvas.value_proposition
     = form_tag project_canvases_path(@project), method: :post, class: 'hypotheses-value-proposition' do
       = text_field_tag :value_proposition, @project.canvas.value_proposition


### PR DESCRIPTION
#### Trello card reference

https://trello.com/c/hx7nalGS/76-bug-value-prop-centers-on-screen-when-you-expand-browser-width-rather-than-staying-left-aligned
#### Progress

Fix bug that made Value Proposition title wasn't aligned at the left. 
### Preview

![out](https://cloud.githubusercontent.com/assets/6147409/10083043/f46dc80e-62d2-11e5-8f06-0c6eb6289255.gif)
