### PR TITLE
Story/110/ac constraint focus story

### DIFF
--- a/app/assets/javascripts/userStories/init.js
+++ b/app/assets/javascripts/userStories/init.js
@@ -25,6 +25,8 @@ ARBOR.user_stories.init = function() {
       $userStoryForm.html('');
       $userStoryForm.html(editForm);
       bindEditForm();
+      bindAcceptanceCriterion();
+      bindConstraint();
     });
   }
 
@@ -94,28 +96,58 @@ ARBOR.user_stories.init = function() {
     return false;
   });
 
-  function bindEditForm() {
-    $editForm = $('form.edit-story.edit_user_story');
+  function editFormAjax(url, type, current_object){
+    hideBacklog();
 
-    $editForm.submit(function() {
+    $.ajax({
+      type: type,
+      url: url,
+      data: current_object,
+      success: function (response) {
+        if(response.success) {
+          refreshBacklog();
+          editUrl = response.data.edit_url
+          displayStoryForm(editUrl);
+        }
+      }
+    });
+  }
+
+  function bindAcceptanceCriterion() {
+    $newCriterionForm = $('.new_acceptance_criterion');
+
+    $newCriterionForm.submit(function() {
+      var url        = $(this).attr('action'),
+          type       = $(this).attr('method'),
+          acriterion = $(this).serialize();
+
+      editFormAjax(url, type, acriterion);
+      return false;
+    });
+  }
+
+  function bindEditForm() {
+    $editUserStoryForm = $('form.edit-story.edit_user_story');
+
+    $editUserStoryForm.submit(function() {
       var url       = $(this).attr('action'),
           type      = $(this).attr('method'),
           userStory = $(this).serialize();
 
-      hideBacklog();
+      editFormAjax(url, type, userStory);
+      return false;
+    });
+  }
 
-      $.ajax({
-        type: type,
-        url: url,
-        data: userStory,
-        success: function (response) {
-          if(response.success) {
-            refreshBacklog();
-            editUrl = response.data.edit_url
-            displayStoryForm(editUrl);
-          }
-        }
-      });
+  function bindConstraint() {
+    $newConstraintForm = $('.new_constraint');
+
+    $newConstraintForm.submit(function() {
+      var url        = $(this).attr('action'),
+          type       = $(this).attr('method'),
+          constraint = $(this).serialize();
+
+      editFormAjax(url, type, constraint);
       return false;
     });
   }

--- a/app/controllers/acceptance_criterions_controller.rb
+++ b/app/controllers/acceptance_criterions_controller.rb
@@ -3,16 +3,10 @@ class AcceptanceCriterionsController < ApplicationController
   before_action :set_acceptance_criterion, only: :update
 
   def create
-    acceptance_criterion = AcceptanceCriterion.new(acceptance_criterion_params)
-    acceptance_criterion.user_story = @user_story
-
-    if acceptance_criterion.save
-      @user_story.acceptance_criterions << acceptance_criterion
-    else
-      flash[:alert] = acceptance_criterion.errors.full_messages[0]
-    end
-
-    redirect_to :back
+    @ac_service = AcceptanceCriterionServices.new(@user_story)
+    response =
+      @ac_service.new_acceptance_criterion(acceptance_criterion_params)
+    render json: response
   end
 
   def update

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -3,15 +3,10 @@ class ConstraintsController < ApplicationController
   before_action :set_user_story, only: :create
 
   def create
-    constraint = Constraint.new(constraint_params)
-    constraint.user_story = @user_story
-    if constraint.save
-      @user_story.constraints << constraint
-    else
-      flash[:alert] = acceptance_criterion.errors.full_messages[0]
-    end
-
-    redirect_to :back
+    @constraint_service = ConstraintServices.new(@user_story)
+    response =
+      @constraint_service.new_constraint(constraint_params)
+    render json: response
   end
 
   def update

--- a/app/services/acceptance_criterion_services.rb
+++ b/app/services/acceptance_criterion_services.rb
@@ -1,0 +1,28 @@
+class AcceptanceCriterionServices
+  def initialize(user_story)
+    @user_story = user_story
+    @common_response = CommonResponse.new(true, [])
+    @route_helper = Rails.application.routes.url_helpers
+  end
+
+  def new_acceptance_criterion(acceptance_criterion_params)
+    acceptance_criterion = AcceptanceCriterion.new(acceptance_criterion_params)
+    acceptance_criterion.user_story = @user_story
+
+    if acceptance_criterion.save
+      assign_common_response(acceptance_criterion)
+    else
+      @common_response.success = false
+      @common_response.errors += acceptance_criterion.errors.full_messages
+    end
+    @common_response
+  end
+
+  private
+
+  def assign_common_response(acceptance_criterion)
+    @user_story.acceptance_criterions << acceptance_criterion
+    @common_response.data[:edit_url] =
+      @route_helper.edit_user_story_path(@user_story)
+  end
+end

--- a/app/services/constraint_services.rb
+++ b/app/services/constraint_services.rb
@@ -1,0 +1,28 @@
+class ConstraintServices
+  def initialize(user_story)
+    @user_story = user_story
+    @common_response = CommonResponse.new(true, [])
+    @route_helper = Rails.application.routes.url_helpers
+  end
+
+  def new_constraint(constraint_params)
+    constraint = Constraint.new(constraint_params)
+    constraint.user_story = @user_story
+
+    if constraint.save
+      assign_common_response(constraint)
+    else
+      @common_response.success = false
+      @common_response.errors += constraint.errors.full_messages
+    end
+    @common_response
+  end
+
+  private
+
+  def assign_common_response(constraint)
+    @user_story.constraints << constraint
+    @common_response.data[:edit_url] =
+      @route_helper.edit_user_story_path(@user_story)
+  end
+end

--- a/spec/controllers/acceptance_criterions_controller_spec.rb
+++ b/spec/controllers/acceptance_criterions_controller_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe AcceptanceCriterionsController do
           user_story_id:        user_story.id,
           acceptance_criterion: { description: 'My new description'}
         )
-        expect(response).to be_redirect
         expect(AcceptanceCriterion.count).to eq 1
+        hash_response = JSON.parse(response.body)
+        expect(hash_response['success']).to eq(true)
+        expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
       end
 
       it 'should edit criterion' do

--- a/spec/controllers/constraints_controller_spec.rb
+++ b/spec/controllers/constraints_controller_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe ConstraintsController do
           user_story_id: user_story.id,
           constraint:    { description: 'My new description' }
         )
-        expect(response).to be_redirect
         expect(Constraint.count).to eq 1
+        hash_response = JSON.parse(response.body)
+        expect(hash_response['success']).to eq(true)
+        expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
       end
 
       it 'should edit constraint' do

--- a/spec/services/acceptance_criterion_services_spec.rb
+++ b/spec/services/acceptance_criterion_services_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+feature 'create acceptance criterion' do
+  let(:project)    { create :project }
+  let(:user_story) { create :user_story }
+  let(:ac_service) { AcceptanceCriterionServices.new(user_story) }
+  let(:ac_params)  {
+    {
+      user_story_id: user_story.id,
+      description: 'My new description'
+    }
+  }
+
+  scenario 'should create an Acceptance Criterion and assign the user story' do
+    response = ac_service.new_acceptance_criterion(ac_params)
+    expect(response.success).to eq(true)
+    ac = AcceptanceCriterion.last
+    expect(ac).to be_a(AcceptanceCriterion)
+    expect(ac.description).to eq('My new description')
+    expect(ac.user_story).to eq(user_story)
+  end
+end

--- a/spec/services/constraint_services_spec.rb
+++ b/spec/services/constraint_services_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+feature 'create constraint' do
+  let(:project)    { create :project }
+  let(:user_story) { create :user_story }
+  let(:constraint_service) { ConstraintServices.new(user_story) }
+  let(:constraint_params)  {
+    {
+      user_story_id: user_story.id,
+      description: 'My new description'
+    }
+  }
+
+  scenario 'should create a Constraint and assign the user story' do
+    response = constraint_service.new_constraint(constraint_params)
+    expect(response.success).to eq(true)
+    constraint = Constraint.last
+    expect(constraint).to be_a(Constraint)
+    expect(constraint.description).to eq('My new description')
+    expect(constraint.user_story).to eq(user_story)
+  end
+end


### PR DESCRIPTION
Story [110] - When creating a new constraint or acceptance criterion on the backlog, keep the related user story form open so that i can add more elements.

https://trello.com/c/UaQbCrPn/110-110-keep-focus-of-selected-user-story-after-creating-a-new-constraint-or-acceptance-criterion

CC:
@pgonzaga2012 

Risk:
Medium
