### PR TITLE
Link log on sidebar and adapt existing tests.

### DIFF
--- a/app/views/hypotheses/index.haml
+++ b/app/views/hypotheses/index.haml
@@ -9,9 +9,6 @@
     = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
       = image_tag('icons/export-icon.svg', class: 'icon')
       = t('top_nav.export')
-    = link_to log_project_path(@project), {'data-reveal-id' => 'log-modal', 'data-reveal-ajax' => true} do
-      = image_tag('icons/export-icon.svg', class: 'icon')
-      = t('labs.log')
     %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
       %li#csv_export_link
         = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)

--- a/app/views/layouts/_sidebar.haml
+++ b/app/views/layouts/_sidebar.haml
@@ -47,9 +47,10 @@
             = render 'shareable/svg/members_icon'
             = t('sidebar.members')
         %li
-          = link_to '#', title: "#{current_project.name} Activity" do
+          = link_to log_project_path(@project), {'data-reveal-id' => 'log-modal', 'data-reveal-ajax' => true} do
             = render 'shareable/svg/activity_icon'
             = t('sidebar.activity')
+
   %ul.footer
     %li
       %p

--- a/spec/features/project/lab_log_spec.rb
+++ b/spec/features/project/lab_log_spec.rb
@@ -192,18 +192,18 @@ feature 'Log lab activity' do
       PublicActivity.with_tracking do
         @project = create :project, owner: user
       end
-      visit project_hypotheses_path @project
+      visit project_path(@project)
     end
 
-    scenario 'should show the link to access the log' do
-      within 'div#top-nav' do
-        expect(page).to have_link 'Latest changes'
+    scenario 'should show the Activity link on the sidebar to access the log' do
+      within '#sidebar' do
+        expect(page).to have_link 'Activity'
       end
     end
 
     scenario 'should display the log after following the link' do
-      within 'div#top-nav' do
-        click_link 'Latest changes'
+      within '#sidebar' do
+        click_link 'Activity'
       end
 
       expect(page).to have_content 'The project was created'
@@ -216,7 +216,9 @@ feature 'Log lab activity' do
         PublicActivity.with_tracking do
           @project.hypotheses << create_list(:hypothesis, 10, project: @project)
         end
-        click_link 'Latest changes'
+        within '#sidebar' do
+          click_link 'Activity'
+        end
       end
 
       scenario 'should have 22 activities to work with' do


### PR DESCRIPTION
https://trello.com/c/IUM654X7/132-1-link-the-activity-log-to-the-link-in-the-sidebar-and-remove-the-link-from-the-lab-section

Trello Card Number # 132

Remove link to log on Lab view and add it to sidebar 'Activity' link which was unused.
Adapt tests.

CC: @pgonzaga2012 

Risks: Low
