### PR TITLE
Link log on sidebar and adapt tests.

### DIFF
--- a/app/views/hypotheses/index.haml
+++ b/app/views/hypotheses/index.haml
@@ -9,9 +9,6 @@
     = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
       = image_tag('icons/export-icon.svg', class: 'icon')
       = t('top_nav.export')
-    = link_to log_project_path(@project), {'data-reveal-id' => 'log-modal', 'data-reveal-ajax' => true} do
-      = image_tag('icons/export-icon.svg', class: 'icon')
-      = t('labs.log')
     %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
       %li#csv_export_link
         = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)
@@ -47,4 +44,3 @@
       .content.row
         = render 'hypotheses/new', hypothesis: @hypothesis,
         hypothesis_types: @hypothesis_types, project: @project
-#log-modal.reveal-modal{"data-reveal" => ""}

--- a/app/views/layouts/_sidebar.haml
+++ b/app/views/layouts/_sidebar.haml
@@ -15,6 +15,8 @@
           %span.icon-edit
     %li
       =link_to t('create_project.project_button'), new_project_path, title: t('create_project.project_button'), class: 'button radius small success'
+      =link_to new_project_path, title: t('create_project.project_button'), class: 'create-project-icon' do
+        %span.icon-plus
   - if current_project && !current_project.new_record?
     .toolbar
       %ul#workspace
@@ -47,7 +49,7 @@
             = render 'shareable/svg/members_icon'
             = t('sidebar.members')
         %li
-          = link_to '#', title: "#{current_project.name} Activity" do
+          = link_to log_project_path(current_project), { data: { reveal_id: 'log-modal', reveal_ajax: true } } do
             = render 'shareable/svg/activity_icon'
             = t('sidebar.activity')
   %ul.footer
@@ -61,3 +63,4 @@
         = t('sidebar.version') + ENV['SIDEBAR_VERSION']
       = link_to '#', title: t('sidebar.collapse'), class: 'collapse' do
         %span.icon-left
+#log-modal.reveal-modal{ data: { reveal: '' } }

--- a/spec/features/project/lab_log_spec.rb
+++ b/spec/features/project/lab_log_spec.rb
@@ -192,18 +192,18 @@ feature 'Log lab activity' do
       PublicActivity.with_tracking do
         @project = create :project, owner: user
       end
-      visit project_hypotheses_path @project
+      visit project_path(@project)
     end
 
-    scenario 'should show the link to access the log' do
-      within 'div#top-nav' do
-        expect(page).to have_link 'Latest changes'
+    scenario 'should show the Activity link on the sidebar to access the log' do
+      within '#sidebar' do
+        expect(page).to have_link 'Activity'
       end
     end
 
     scenario 'should display the log after following the link' do
-      within 'div#top-nav' do
-        click_link 'Latest changes'
+      within '#sidebar' do
+        click_link 'Activity'
       end
 
       expect(page).to have_content 'The project was created'
@@ -216,7 +216,9 @@ feature 'Log lab activity' do
         PublicActivity.with_tracking do
           @project.hypotheses << create_list(:hypothesis, 10, project: @project)
         end
-        click_link 'Latest changes'
+        within '#sidebar' do
+          click_link 'Activity'
+        end
       end
 
       scenario 'should have 22 activities to work with' do


### PR DESCRIPTION
Trello card 132.

https://trello.com/c/IUM654X7/132-1-link-the-activity-log-to-the-link-in-the-sidebar-and-remove-the-link-from-the-lab-section

Remove log link from lab section and add link to 'activity' on the sidebar.
Adapt tests to new distribution.

CC: @pgonzaga2012 

Risks: Low
