### PR TITLE
Correct Backlog grid

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -3,6 +3,8 @@
 // --------------------------------------------------------
 
 .backlog {
+  margin: 0;
+
   .user-stories {
     border-right: 1px solid $black-10;
     color: $secondary-color;
@@ -12,7 +14,7 @@
 
     .user-story {
       border-bottom: 1px solid $black-10;
-      padding: rem-calc(20 40 20 0);
+      padding: rem-calc(20 40 20 15);
       position: relative;
 
       .hover-options {
@@ -91,7 +93,7 @@
   } // user stories
 
   .user-story-edit-form {
-    padding: rem-calc(20 0 0 30);
+    padding: rem-calc(20 0 0 20);
 
     input {
       @include inline-block();


### PR DESCRIPTION
### Comments

Deleted foundation's row margins in order to gain space at the right when the sidebar is collapsed. It also avoids white space on user stories left side when browser's window is enlarged.
### Preview

![out](https://cloud.githubusercontent.com/assets/6147409/10168076/85405370-66a1-11e5-8560-b2c9b3a3638f.gif)
