### PR TITLE
Add margin bottom to constraint form

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -212,6 +212,8 @@
 
     .acceptance-criterion-form,
     .constraint-form {
+      margin-bottom: rem-calc(20);
+
       input {
         color: $secondary-color;
         font-size: rem-calc(16);


### PR DESCRIPTION
### Trello reference

https://trello.com/c/h4BKPCgL/136-bug-136-there-is-no-padding-at-the-bottom-of-the-page-when-entering-constraints-same-problem-when-entering-hypothesis-on-lab
### Description

Adds margin bottom to constraint form.
