### PR TITLE
Add new link for logo image

### DIFF
--- a/app/views/invite_mailer/project_invite_email.html.haml
+++ b/app/views/invite_mailer/project_invite_email.html.haml
@@ -11,7 +11,7 @@
             %table{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%; margin: 0; padding: 0;"}
               %tr{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; margin: 0; padding: 0;"}
                 %td{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; margin: 0; padding: 0;"}
-                  = image_tag attachments['logo.svg'].url, size: "110x70", crop: :fill, :style => "margin: 15px 0 0 210px"
+                  = image_tag ("https://photos-1.dropbox.com/t/2/AADXCs0ywTuvNCO31DbIve6IDtJ9GLVBeEMOVCzeCEvexw/12/320007536/png/32x32/1/1443564000/0/2/arbor-logo.svg/CPDay5gBIAEgAiAHKAIoBw/kbDmMcQQXZKDzby4N_yJJIQc__5y_cvSixrbqnfF158?size=1024x768&size_mode=2"), {:style => "margin: 15px auto; width: 100px; display: table-row-group;"}
                   %h2{:style => "font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif; font-size: 12px; line-height: 1.2; color: #b3b3b3; font-weight: 400; margin: 20px 10px; padding: 0; text-align: center;"}= t("mailer.invite.title")
                   %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: bold; margin: 0 0 10px; padding: 0; color: #747474;"}= t("mailer.invite.someone_invited_you", inviter: @inviter, project_name: @project_name).html_safe
                   %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= t("mailer.invite.description").html_safe
@@ -28,4 +28,3 @@
                       %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= t("mailer.invite.thanks").html_safe
                     %tr
                       %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= t("mailer.invite.arbor").html_safe
-


### PR DESCRIPTION
### Trello reference

https://trello.com/c/UlS9EPlO/133-image-missing-from-email-invite
### Comments

Fixes Arbor's logo image on mail. 

<img width="1392" alt="screen shot 2015-09-30 at 7 04 37 am" src="https://cloud.githubusercontent.com/assets/6147409/10190238/95a42f70-6741-11e5-8110-7a122f663c2c.png">
