### PR TITLE
Fix overlapping between hypothesis & Success Metric 

### DIFF
--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -308,9 +308,8 @@
     color: $font-color-2;
     font-size: rem-calc(15);
     font-weight: $font-weight-bold;
-    height: rem-calc(29);
     margin-bottom: 0;
-    padding: rem-calc(0 0 0 15);
+    padding: rem-calc(0 0 10 15);
     position: relative;
 
     .hypothesis-title {


### PR DESCRIPTION
### Trello reference

https://trello.com/c/phmyR88Y/152-aquisitions-title-and-content-are-bad-placed-when-ever-you-shrink-or-create-a-long-statement-that-takes-more-than-1-line-it-over
### Comments

Fixes hypothesis overlapping with Success metric bug.
### Preview

<img width="1280" alt="screen shot 2015-09-30 at 2 01 30 pm" src="https://cloud.githubusercontent.com/assets/6147409/10200322/fda991fc-677b-11e5-9007-9307fab73b6d.png">
