### PR TITLE
Delete focus blue line on Export dropdown

### DIFF
--- a/app/assets/stylesheets/_top_nav.scss
+++ b/app/assets/stylesheets/_top_nav.scss
@@ -16,4 +16,4 @@
   } // nav links
 
   .f-dropdown:focus { outline-width: 0; }
-}
+} // top nav


### PR DESCRIPTION
### Trello reference

https://trello.com/c/1lIg4wO7/157-clicking-export-triggers-outline-for-modal-not-nice-at-all-on-chrome-link
### Comments

Deletes blue line on Export's 
### Preview

![out](https://cloud.githubusercontent.com/assets/6147409/10201242/5cf5d972-6781-11e5-8a70-3b7d0f00ba1d.gif)
