### PR TITLE
Prevent duplicate error.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,6 +16,10 @@ class Project < ActiveRecord::Base
     super(only: [:name])
   end
 
+  def invite_exists(email)
+    invites.any? { |invite| invite.email == email }
+  end
+
   def reorder_user_stories(user_stories_hash)
     user_stories.update_all backlog_order: nil
 

--- a/app/services/project_member_services.rb
+++ b/app/services/project_member_services.rb
@@ -38,7 +38,10 @@ class ProjectMemberServices
   end
 
   def invite_new_user(data)
-    @project.invites << Invite.create(email: data[:email])
+    email = data[:email]
+
+    @project.invites <<
+      Invite.create(email: email) unless @project.invite_exists(email)
     InviteMailer.project_invite_email(data, true).deliver_now
   end
 end


### PR DESCRIPTION
https://trello.com/c/mrCPVAsg/124-124-bug-make-error-message-on-duplicate-invite-more-informative

Trello card number124

Removed duplicate error so that if someone invites a member that has already been invited no error is displayed. An email is resent to the member.

Risk: Low
