### PR TITLE
Fix padding creating extra border on user stories

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -6,19 +6,18 @@
   margin: 0;
 
   .user-stories {
-    border-right: 1px solid $black-10;
     color: $secondary-color;
-    padding: rem-calc(0 0 20 0);
 
     ul { font-size: rem-calc(14); } // ul
 
     .user-story {
       border-bottom: 1px solid $black-10;
+      border-right: 1px solid $black-10;
       padding: rem-calc(20 40 20 15);
       position: relative;
 
       .hover-options {
-        @include opacity(0); // 0
+        @include opacity(0); 
         background-color: $black-10;
         border-left: 1px solid $black-20;
         height: 100%;


### PR DESCRIPTION
### Trello reference

https://trello.com/c/tTtUSH4S/148-padding-on-stories-container-creating-more-border
### Comments

Added border to each user story, instead of adding it to the whole div to avoid border coming out of the box.
### Preview

<img width="654" alt="screen shot 2015-09-30 at 5 19 24 pm" src="https://cloud.githubusercontent.com/assets/6147409/10205545/22cf2976-6798-11e5-8beb-b7a76c1dbac8.png">
