### PR TITLE
Story/123/succes metric non mandatory

### DIFF
--- a/app/assets/javascripts/hypotheses/show.js
+++ b/app/assets/javascripts/hypotheses/show.js
@@ -2,26 +2,35 @@ $(document).ready(function() {
   var $hypothesisShow     = $('.hypothesis-show'),
       $hypothesisShowType = $('.hypothesis-type-show');
 
+
   function displayEditForm(hypothesisId) {
     var $editHypothesisById = $('.hypothesis-edit[data-id=' +
       hypothesisId + ']'),
-        $editHypothesisByIdType = $('.hypothesis-type-edit[data-id=' +
-          hypothesisId + ']'),
         $hypothesisShowById =$('.hypothesis-show[data-id=' +
           hypothesisId + ']'),
-        $hypothesisShowTypeById = $('.hypothesis-type-show[data-id=' +
-          hypothesisId + ']'),
-        $editHypothesis = $('.hypothesis-edit'),
-        $editHypothesisType  = $('.hypothesis-type-edit');
+        $editHypothesis = $('.hypothesis-edit');
 
     $hypothesisShow.show();
-    $hypothesisShowType.show();
     $hypothesisShowById.hide();
-    $hypothesisShowTypeById.hide();
     $editHypothesis.hide();
-    $editHypothesisType.hide();
     $editHypothesisById.show();
-    $editHypothesisByIdType.show();
+  }
+
+  function setType() {
+    var selectedOption = $('.type option:selected');
+
+    selectedOption.each(function() {
+      var $this = $(this),
+          $span = $this.parent().siblings('.dynamic-width');
+
+      if (!$this.val() == '') {
+        $this.parent().removeClass('empty');
+        $span.html($this.text());
+        $this.parent().width($span.width());
+      } else {
+        $this.parent().addClass('empty');
+      }
+    });
   }
 
   $hypothesisShow.click(function() {
@@ -34,6 +43,7 @@ $(document).ready(function() {
     displayEditForm(hypothesisId);
   });
 
+  new setType();
   new UserStory();
   new Goal();
 });

--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -37,25 +37,6 @@
     border: 1px solid $border-color;
     padding: rem-calc(20);
   }
-
-  .hypothesis-type-show {
-    @include border-radius(50px);
-    background-color: $lab-color;
-    border: 2px solid $lab-color;
-    clear: both;
-    color: $white;
-    cursor: pointer;
-    display: inline-block;
-    font-size: rem-calc(8);
-    font-weight: $font-weight-bold;
-    line-height: normal;
-    margin: rem-calc(6 0 6 16);
-    padding: rem-calc(3 7);
-    text-align: center;
-    text-transform: uppercase;
-
-    &:hover +.click-edit { display: inline-block; }
-  } // success metric show
 }
 
 .hypothesis {
@@ -66,7 +47,7 @@
   margin: rem-calc(0 20);
   padding: rem-calc(20);
 
-  &:hover .description .icon-trash { @include opacity(1); }
+  .hypothesis-form:hover .description .icon-trash { @include opacity(1); }
 
   span {
     @include transition(opacity .25s ease-in, color .25s ease-in);
@@ -153,17 +134,21 @@
 
   .enter,
   .click-edit {
+    color: $font-color-3;
     display: none;
     font-size: rem-calc(10);
+    font-weight: $font-weight-normal;
     vertical-align: middle;
   }
+
+  .enter { vertical-align: top; }
 
   .row {
     max-width: 100%;
     position: relative;
 
     &.editing {
-      .enter { @include opacity(1); }
+      .enter { display: inline-block; }
       .epic span { @include opacity(1); }
       .user-story-input { font-weight: $font-weight-bold; }
       .new-story .epic label::before { border-color: $lab-color; }
@@ -314,6 +299,9 @@
 
     .hypothesis-title {
       @include single-transition(color, .25s, ease-in);
+      cursor: text;
+
+      &:hover { color: $font-color-3; }
 
       .hypothesis-title-field {
         margin-bottom: 0;
@@ -378,7 +366,7 @@
           color: $white;
           content: '✔';
           font-size: rem-calc(4);
-          left: rem-calc(5);
+          left: rem-calc(4);
           line-height: 0;
           position: absolute;
           top: rem-calc(7);
@@ -404,7 +392,7 @@
   .hypothesis {
     border: 0;
 
-    .bullet { top: rem-calc(2); }
+    .bullet { top: rem-calc(-2); }
   }
 
   input,
@@ -431,15 +419,7 @@
 
 }//hypothesis new
 
-.hypothesis-edit {
-  display: none;
-  min-height: rem-calc(60);
-
-  .hypothesis-type {
-    height: 3px;
-  }// .hypothesis-type
-
-}// hypothesis edit
+.hypothesis-edit { display: none; }
 
 .success-items {
   position: relative;
@@ -478,23 +458,42 @@
   } // radio btn
 } // success items
 
+.hypothesis-new,
 .hypothesis-type-edit {
-  display: none;
-}// hypothesis edit
-
-.hypothesis-type-edit,
-.hypothesis-new {
   padding-left: 0;
 
   select {
-    @include border-radius(50px);
-    border: 1px solid $black-20;
-    font-size: rem-calc(10);
-    height: rem-calc(25);
+    @include transition(none);
+    @include border-radius(rem-calc(50));
+    background-image: none;
+    cursor: pointer;
+    font-size: rem-calc(9);
+    height: rem-calc(20);
     margin-bottom: rem-calc(5);
-    padding: rem-calc(0 0 0 10);
+    padding: rem-calc(0 9 0 10);
     text-transform: uppercase;
-    width: 16%;
+    vertical-align: baseline;
+    width: auto;
+
+    &.edit-type {
+      background-color: $lab-color;
+      border: 0;
+      color: $white;
+    }
+
+    &.empty {
+      background-color: $transparent;
+      border: 1px solid $font-color-3;
+      color: $font-color-3;
+    }
+
+    &:hover + .click-edit { display: inline-block; }
+  }
+
+  .dynamic-width {
+    display: none;
+    font-size: rem-calc(9);
+    text-transform: uppercase;
   }
 }// hypothesis edit
 

--- a/app/models/hypothesis.rb
+++ b/app/models/hypothesis.rb
@@ -1,5 +1,5 @@
 class Hypothesis < ActiveRecord::Base
-  validates_presence_of :description, :hypothesis_type, :project
+  validates_presence_of :description, :project
   validates_uniqueness_of :description, scope: :project_id
   validates_uniqueness_of :order, scope: :project_id
   before_create :order_in_project
@@ -9,7 +9,12 @@ class Hypothesis < ActiveRecord::Base
   has_many :user_stories
   has_many :goals, dependent: :destroy
 
-  delegate :description, :code, to: :hypothesis_type, prefix: true
+  delegate :description,
+           :code,
+           to: :hypothesis_type,
+           prefix: true,
+           allow_nil: true
+
   delegate :name, to: :project, prefix: true
 
   include AssociationLoggable
@@ -35,7 +40,7 @@ class Hypothesis < ActiveRecord::Base
   end
 
   def type
-    hypothesis_type.as_json
+    hypothesis_type.as_json if hypothesis_type
   end
 
   def reorder_user_stories(user_stories_hash)

--- a/app/views/hypotheses/_edit.haml
+++ b/app/views/hypotheses/_edit.haml
@@ -1,16 +1,12 @@
-.description.hypothesis-edit{ data: { id: hypothesis.id } }
-  = link_to                        |
-     hypothesis_path(hypothesis),  |
-     method: :delete,              |
-     class: 'delete-hypothesis',   |
-     title: 'Delete Hypothesis' do |
-    %span.icon-trash
+.description
   = form_for hypothesis do |form|
-    .hypothesis-title
+    .hypothesis-title.hypothesis-edit{ data: { id: hypothesis.id } }
       %span.bullet
       = form.text_field :description, class: 'hypothesis-title-field',
       data: { hypothesis_id: hypothesis.id }
     .small-12.columns.hypothesis-type-edit{ data: { id: hypothesis.id } }
       = form.select(:hypothesis_type_id,
-      hypothesis_types.all.collect { |ht|[ht.description, ht.id] }, {}, { class: 'type edit-type' })
+      hypothesis_types.all.collect { |ht|[ht.description, ht.id] }, { include_blank: t('labs.hypotheses.select_metric')}, { class: 'type edit-type' })
+      .click-edit= t('labs.hypotheses.edit')
+      %span.dynamic-width
     = form.submit :save, class: 'hide'

--- a/app/views/hypotheses/_new.haml
+++ b/app/views/hypotheses/_new.haml
@@ -4,5 +4,5 @@
     required: true, maxlength: 250, class: 'description' + (hypothesis.errors.any? ? '-error' : '')
   .small-12.columns{ data: { id: hypothesis.id } }
     = form.select(:hypothesis_type_id,
-    hypothesis_types.all.collect { |ht|[ht.description, ht.id] }, {}, { class: 'type' })
+    hypothesis_types.all.collect { |ht|[ht.description, ht.id] }, { include_blank: t('labs.hypotheses.select_metric') }, { class: 'type' })
   = form.submit I18n.translate('save'), class: 'hide'

--- a/app/views/hypotheses/_show.haml
+++ b/app/views/hypotheses/_show.haml
@@ -2,7 +2,6 @@
   = image_tag 'preloader.gif'
 .hypothesis{ data: { id: hypothesis.id, order: hypothesis.order } }
   .hypothesis-form.clearfix
-    = render 'hypotheses/edit', hypothesis: hypothesis, hypothesis_types: hypothesis_types
     .description.large-12.columns.hypothesis-show{ data: { id: hypothesis.id } }
       = link_to                        |
          hypothesis_path(hypothesis),  |
@@ -10,11 +9,10 @@
          class: 'delete-hypothesis',   |
          title: 'Delete Hypothesis' do |
         %span.icon-trash
-      .hypothesis-title
+      .hypothesis-title{ title: t('labs.hypotheses.edit_title') }
         %span.bullet
         = hypothesis.description
-    .type.hypothesis-type-show{ data: { id: hypothesis.id } }= hypothesis.hypothesis_type_description
-    .click-edit - click here to edit
+    = render 'hypotheses/edit', hypothesis: hypothesis, hypothesis_types: hypothesis_types
   .content.row.collapse
     .goals
       - if hypothesis.goals.any?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,8 +48,11 @@ en:
   labs:
     undefined_hypothesis: 'Undefined hypotheses'
     hypotheses:
+      edit: "- edit success metric"
+      edit_title: "Edit Hypothesis Title"
       enter_description: "Write a new hypothesis"
       export: "Export"
+      select_metric: 'Select a success metric'
     goals:
       title: "Title"
       enter_title: "Enter Title"

--- a/spec/features/project/hypothesis/create_hypothesis_spec.rb
+++ b/spec/features/project/hypothesis/create_hypothesis_spec.rb
@@ -22,7 +22,10 @@ feature 'Create hypothesis' do
     within '.hypothesis-show' do
       expect(find('.hypothesis-title')).to have_text(hypothesis_description)
     end
-    expect(find('.hypothesis-type-show')).to have_text(hypothesis_type.description)
+
+    within '.hypothesis-type-edit' do
+      expect(find('#hypothesis_hypothesis_type_id')).to have_text(hypothesis_type.description)
+    end
   end
 
   scenario 'create hypothesis without description' do

--- a/spec/features/project/hypothesis/edit_spec.rb
+++ b/spec/features/project/hypothesis/edit_spec.rb
@@ -12,20 +12,13 @@ feature 'Edit hypothesis' do
 
   scenario 'edit form is diplayed when clicking on hypothesis title' do
     find('.hypothesis-show').click
-    expect(page).to have_css '.hypothesis-edit'
-    expect(page).to have_css '.hypothesis-type-edit'
-  end
-
-  scenario 'edit form is diplayed when clicking on hypothesis type' do
-    find('.hypothesis-type-show').click
-    expect(page).to have_css '.hypothesis-edit'
-    expect(page).to have_css '.hypothesis-type-edit'
+    expect(page).to have_css '.hypothesis-title-field'
   end
 
   scenario 'edit hypothesis title' do
     updated_title =  'MY NEW HYPOTHESIS TITLE'
 
-    find('.hypothesis-type-show').click
+    find('.hypothesis-show').click
 
     within '.hypothesis-edit' do
       find('.hypothesis-title-field').set(updated_title)

--- a/spec/models/hypothesis_spec.rb
+++ b/spec/models/hypothesis_spec.rb
@@ -7,7 +7,6 @@ describe Hypothesis do
 
   it { should validate_presence_of :description }
   it { should validate_presence_of :project }
-  it { should validate_presence_of :hypothesis_type }
   it { should belong_to :project }
   it { should belong_to :hypothesis_type }
 


### PR DESCRIPTION
[#123](https://trello.com/c/bUi45ZH8/123-123-2-as-a-user-i-want-to-choose-the-success-metric-for-a-hypothesis-separately) As a user I want to choose the success metric for a hypothesis separately.

Given that I am creating a new hypothesis, when I choose not to select the metric type, I should be able to submit the new hypothesis just with the title and I should be able to select the metric type any other time.
Given that I did not select the metric type then I should see a placeholder that says "Choose your success metric".
## Tasks
- [x] Make the success metric not mandatory
- [x] Change the default option of the success metric to an empty string
- [x] Display a helpful placeholder on the select so that the user has some input on what to select IE : "Choose your success metric".
## References
- https://trello.com/c/bUi45ZH8/123-123-2-as-a-user-i-want-to-choose-the-success-metric-for-a-hypothesis-separately
## Risks

**Low.**
## Screenshot

![screen shot 2015-09-21 at 2 54 59 pm](https://trello-attachments.s3.amazonaws.com/560035616eaae8f6c22586a5/2184x1554/9ca74b9c11dbb892415ab9b13350e98c/Screenshot_2015-10-01_15.30.59.png)
