### PR TITLE
Bug/162/order user stories backlog

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,7 +59,12 @@ class ProjectsController < ApplicationController
   end
 
   def backlog
-    project = Project.find(params[:project_id])
+    project = Project.includes(
+      user_stories: [:acceptance_criterions, :constraints],
+      members: {},
+      hypotheses: {})
+              .order('user_stories.backlog_order')
+              .find(params[:project_id])
     render partial: 'user_stories/backlog_list', locals: { project: project }
   end
 

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -64,10 +64,7 @@ class UserStoriesController < ApplicationController
   def set_project
     @project =
       @user_story.try(:project) ||
-      Project
-      .includes(user_stories: [:acceptance_criterions],
-                members: {},
-                hypotheses: {})
+      Project.includes(:user_stories)
       .order('user_stories.backlog_order')
       .find(params[:project_id])
   end

--- a/app/services/project_services.rb
+++ b/app/services/project_services.rb
@@ -16,8 +16,7 @@ class ProjectServices
   end
 
   def reorder_stories(new_order)
-    @project
-      .reorder_user_stories(new_order)
+    @project.reorder_user_stories(new_order)
     { success: true }
   end
 


### PR DESCRIPTION
https://trello.com/c/5sN1yXcJ/161-when-we-edit-a-user-story-on-the-backlog-section-then-the-order-of-the-user-stories-is-reversed-until-we-refresh-the-page

Cards 161 and 162.

FIxes bug regarding the order of the user stories on the backlog.
