### PR TITLE
Move the logout button out to the layout.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   webmock
-
-BUNDLED WITH
-   1.10.6

--- a/app/views/attachments/index.haml
+++ b/app/views/attachments/index.haml
@@ -1,8 +1,3 @@
-- content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
 %section#attachments
   - if @attachment.errors.any?
     .alert-box.alert.radius.attachment_errors{ data: { alert: '' } }

--- a/app/views/canvases/index.haml
+++ b/app/views/canvases/index.haml
@@ -1,8 +1,3 @@
-- content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
 %section#canvas.row
   .left-content-wrapper.large-6.column
     %h2= @project.name

--- a/app/views/hypotheses/index.haml
+++ b/app/views/hypotheses/index.haml
@@ -2,20 +2,16 @@
 %script{src: "//api.trello.com/1/client.js?key=f351a7f0bd7d8b8924b22ef2677f7738"}
 
 - content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
-    = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
-      = image_tag('icons/export-icon.svg', class: 'icon')
-      = t('top_nav.export')
-    %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
-      %li#csv_export_link
-        = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)
-      %li#json_export_link
-        = link_to t('json'), project_hypotheses_export_path(@project, format: :json)
-      %li#trello_export_link
-        = link_to t('trello.export'), '#'
+  = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
+    = image_tag('icons/export-icon.svg', class: 'icon')
+    = t('top_nav.export')
+  %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
+    %li#csv_export_link
+      = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)
+    %li#json_export_link
+      = link_to t('json'), project_hypotheses_export_path(@project, format: :json)
+    %li#trello_export_link
+      = link_to t('trello.export'), '#'
 - if @project.canvas
   .value-prop
     .title-value-proposition

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -28,7 +28,11 @@
   %body{'data-action' => action_name, 'data-controller' => controller_name }
     = render 'layouts/sidebar', projects: @projects, current_project: @project
     .columns.small-10.right-app-content
-      = yield :top_links
+      #top-nav
+        = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
+          = image_tag('icons/signout-icon.svg', class: 'icon')
+          = t('backlog.logout')
+        = yield :top_links
       .content-general
         = render 'layouts/notices', alert: alert, notice: notice
         = yield

--- a/app/views/projects/index.haml
+++ b/app/views/projects/index.haml
@@ -1,8 +1,3 @@
-- content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
 #new-project.section-margin-top.row
   .large-6.large-centered.columns
     %p.create-project= t('create_project.title')

--- a/app/views/projects/new.haml
+++ b/app/views/projects/new.haml
@@ -1,8 +1,3 @@
-- content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
 #project-info.row
   .section-margin-top.large-6.large-centered.columns
     - if @errors

--- a/app/views/user_stories/index.haml
+++ b/app/views/user_stories/index.haml
@@ -1,24 +1,20 @@
 - content_for :top_links do
-  #top-nav
-    = link_to destroy_user_session_path, method: :delete, class: 'logout nav-links' do
-      = image_tag('icons/signout-icon.svg', class: 'icon')
-      = t('backlog.logout')
-    = link_to '#', class: "nav-links" do
-      = image_tag('icons/search-icon.svg', class: 'icon')
-      = t('top_nav.search')
-    = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
-      = image_tag('icons/export-icon.svg', class: 'icon')
-      = t('top_nav.export')
-    = link_to project_user_stories_path(@project), class: "nav-links" do
-      = image_tag('icons/add-icon.svg', class: 'icon')
-      = t('backlog.user_stories.new')
-    %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
-      %li#csv_export_link
-        = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)
-      %li#json_export_link
-        = link_to t('json'), project_hypotheses_export_path(@project, format: :json)
-      %li#trello_export_link
-        = link_to t('trello.export'), '#'
+  = link_to '#', class: "nav-links" do
+    = image_tag('icons/search-icon.svg', class: 'icon')
+    = t('top_nav.search')
+  = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do
+    = image_tag('icons/export-icon.svg', class: 'icon')
+    = t('top_nav.export')
+  = link_to project_user_stories_path(@project), class: "nav-links" do
+    = image_tag('icons/add-icon.svg', class: 'icon')
+    = t('backlog.user_stories.new')
+  %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
+    %li#csv_export_link
+      = link_to t('csv'), project_hypotheses_export_path(@project, format: :csv)
+    %li#json_export_link
+      = link_to t('json'), project_hypotheses_export_path(@project, format: :json)
+    %li#trello_export_link
+      = link_to t('trello.export'), '#'
 %section.backlog.row{ data: { project_id: @project.id } }
   .user-stories-preloader.large-5.columns
     = image_tag 'preloader.gif'


### PR DESCRIPTION
[#159] Move logout link to layout 
## Notes

Improve the layout moving repeated code to a more DRY approach
## References

https://trello.com/c/4Qdkax5b/159-159-move-the-sign-out-link-to-the-layout
## Risks

Low
