### PR TITLE
autosave when checking epic option.

### DIFF
--- a/app/assets/javascripts/hypotheses/userStory.js
+++ b/app/assets/javascripts/hypotheses/userStory.js
@@ -1,7 +1,8 @@
 function UserStory() {
   var $userStoriesList  = $('.user-story-list'),
       $newUserStoryForm = $('form#new_user_story'),
-      $appContent       = $('.right-app-content');
+      $appContent       = $('.right-app-content'),
+      $epicCheckbox     = $('.user-story-input.epic');
 
   function storiesAreReordered(hypothesisId, stories) {
     var changes = false;
@@ -90,6 +91,11 @@ function UserStory() {
         $appContent.scrollTo($userStoryForm, 200);
     });
   }
+
+  $epicCheckbox.change(function() {
+    var $editForm = $(this).parent();
+    $editForm.submit();
+  });
 
   function bindUserStoriesSortEvent() {
     var storyListSelector = '.user-story-list';


### PR DESCRIPTION
[#149] On lab, autosave 'epic' option when checking the checkbox of a user story

Wasn't really a bug. Users thought the feature was broken because it was necessary to click on the user story to open the edit form, check the box and hit enter to save.
## Tasks

Added js code to submit the edit form on change of the checkbox
## References
- https://trello.com/c/CDJkwqBF/149-149-bug-if-i-created-a-story-and-then-select-it-as-epic-if-i-go-check-another-story-in-the-list-and-come-back-the-epick-checkbox
## Risks

**Low.**
