### PR TITLE
Fix Lab Hypothesis width.

### DIFF
--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -45,7 +45,6 @@
   border-bottom: 1px solid $border-color;
   clear: both;
   color: $font-color-3;
-  margin: rem-calc(0 20);
   padding: rem-calc(20);
 
   .hypothesis-form:hover .description .icon-trash { @include opacity(1); }
@@ -107,7 +106,7 @@
     padding: rem-calc(9 9 9 24);
     position: relative;
     vertical-align: bottom;
-    width: 70%;
+    width: 100%;
     z-index: 1;
 
     &.hide { display: none; }


### PR DESCRIPTION
#### Trello board reference:
- [Trello Card #150](https://trello.com/c/DToveJWY/150-150-filling-first-hypotesis-clamps-the-content-before-reaching-the-far-right-of-the-browser)

---
#### Description:
- Filling first hypothesis clamps the content before reaching the far right of the browser.

---
#### Notes:
- Reduced also de sidebar margin in order to gain more workspace in the **Lab**.

---
#### Tasks:
- [x] Increase lab hypothesis input width to 100%
- [x] Reduce sidebar margin to gain workspace.

---
#### Risk:
- Low

---
#### Preview:

![image](https://trello-attachments.s3.amazonaws.com/560a9fa8823522c24f4dfdfc/2736x738/f40f4f345248b487354a53024d652d1b/Screenshot_2015-10-06_12.09.22.png)
