### PR TITLE
Backlog view columns grid behavior

### DIFF
--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -101,6 +101,7 @@ function UserStories() {
         type      = $(this).attr('method'),
         userStory = $(this).serialize();
 
+    $userStoryForm.removeClass('full-width');
     editFormAjax(url, type, userStory);
     return false;
   });
@@ -183,6 +184,14 @@ function UserStories() {
         $span.html($this.val());
       }
     });
+  }
+}
+
+fullWidthForm();
+
+function fullWidthForm() {
+  if (!$('.user-story-list').is(':visible')) {
+    $('.user-story-edit-form').addClass('full-width');
   }
 }
 

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -3,14 +3,21 @@
 // --------------------------------------------------------
 
 .backlog.row {
+  height: 100%;
   margin: 0;
   max-width: 100%;
   position: relative;
 
-  .user-stories-list-container { padding: 0; }
+  .user-stories-list-container {
+    max-height: 100%;
+    overflow: hidden;
+    overflow-y: auto;
+    padding: 0;
+  }
 
   .user-stories {
     color: $secondary-color;
+    min-height: 100%;
 
     ul {
       font-size: rem-calc(14);
@@ -20,7 +27,6 @@
     .user-story {
       @include transition(background-color .25s ease-in);
       border-bottom: 1px solid $black-10;
-      border-right: 1px solid $black-10;
       cursor: pointer;
       padding: rem-calc(20 45 20 15);
       position: relative;
@@ -123,7 +129,15 @@
   }
 
   .user-story-edit-form {
-    padding: rem-calc(20 0 0 20);
+    border-left: 1px solid $black-10;
+    height: 100%;
+    overflow-y: auto;
+    padding: rem-calc(20 20 0 20);
+
+    &.full-width {
+      border: 0;
+      width: 100%;
+    }
 
     input {
       @include inline-block();

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -11,7 +11,10 @@ body {
   overflow-y: scroll;
   padding: 0;
 
-  .content-general { padding: rem-calc(0 15); }
+  .content-general {
+    height: calc(100% - 4.0625rem);
+    padding: rem-calc(0 15);
+  }
 }
 
 //Remove focus styles


### PR DESCRIPTION
#### Trello board reference:
- [Trello Card #125](https://trello.com/c/xMsqatsz/125-125-bug-on-backlog-when-there-s-no-user-stories-added-yet-right-column-should-be-100-width)

---
#### Description:
- On Backlog, when there's no user stories added yet, right column should be 100% width. When the first user story is added, the width must be reduced again dynamically.

---
#### Notes:
- Fixed the **form** border, making it full height.
- Also added individual scrolls to both the **user stories** list and **form**. 

---
#### Tasks:
- [x] Add full width to form if there aren't user stories created.
- [x] Remove form full width if a user story is created.
- [x] Fix form border-left.
- [x] Extend form and user stories list to full-height.
- [x]  Add a scroll functionality for each user stories list and form separately.

---
#### Risk:
- Medium

---
#### Preview:

![image](https://trello-attachments.s3.amazonaws.com/5601c53aaac7ec0a765351cd/593x279/f10df42744ab3224791b7af5a76ddd51/backlog.gif)
