### PR TITLE
Fixed asset precompilation issue.

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,2 +1,0 @@
-Rails.application.config.assets.version = '2.6.0'
-Rails.application.config.assets.precompile = %w(*.js)


### PR DESCRIPTION
## Review Branch for 10/09/2015
#### Trello board reference:
- [Trello Card #]()

---
#### Description:
- It's the state of the master branch from 10/09/2015.

---
#### Reviewers:
- 

---
#### Notes:
- We had to remove the assets.rb file because it prevented heroku from precompiling the assets which caused missing stylesheet information.

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
