### PR TITLE
Finish json response fix and test.

### DIFF
--- a/app/controllers/acceptance_criterions_controller.rb
+++ b/app/controllers/acceptance_criterions_controller.rb
@@ -6,7 +6,7 @@ class AcceptanceCriterionsController < ApplicationController
     @ac_service = AcceptanceCriterionServices.new(@user_story)
     response =
       @ac_service.new_acceptance_criterion(acceptance_criterion_params)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   def update
@@ -15,7 +15,7 @@ class AcceptanceCriterionsController < ApplicationController
       AcceptanceCriterionServices.new(@acceptance_criterion.user_story)
     response =
       @ac_service.update_acceptance_criterion(@acceptance_criterion)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   private

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -6,7 +6,7 @@ class ConstraintsController < ApplicationController
     @constraint_service = ConstraintServices.new(@user_story)
     response =
       @constraint_service.new_constraint(constraint_params)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   def update
@@ -14,7 +14,7 @@ class ConstraintsController < ApplicationController
     @constraint_service = ConstraintServices.new(@constraint.user_story)
     response =
       @constraint_service.update_constraint(@constraint)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   private

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -21,7 +21,7 @@ class UserStoriesController < ApplicationController
     @user_story_service = UserStoryService.new(@project, @hypothesis)
     response =
       @user_story_service.new_user_story(user_story_params)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   def update
@@ -56,7 +56,7 @@ class UserStoriesController < ApplicationController
 
   def json_update
     response = UserStoryService.new(@project).update_user_story(@user_story)
-    render json: response
+    render json: response, status: (response.success ? 201 : 422)
   end
 
   def html_update

--- a/spec/features/project/acceptance_criteria/create_acceptance_criterion_spec.rb
+++ b/spec/features/project/acceptance_criteria/create_acceptance_criterion_spec.rb
@@ -4,7 +4,7 @@ feature 'Create a new acceptance criterion' do
   let!(:user)                 { create :user }
   let!(:project)              { create :project, owner: user }
   let!(:user_story)           { create :user_story, project: project }
-  let(:acceptance_criterion)  { build :acceptance_criterion }
+  let(:acceptance_criterion)  { build :acceptance_criterion, description: 'My description'  }
 
   background do
     sign_in user
@@ -30,5 +30,30 @@ feature 'Create a new acceptance criterion' do
       find('input#save-acceptance-criterion', visible: false).trigger('click')
     end
     expect(AcceptanceCriterion.count).to eq 1
+  end
+
+  def new_ac
+    within 'form.new_acceptance_criterion' do
+      fill_in(
+        :acceptance_criterion_description,
+        with: 'acceptance_criterion.description'
+      )
+      find('input#save-acceptance-criterion', visible: false).trigger('click')
+    end
+  end
+
+  scenario 'should show an error with duplicate acceptance criterions', js: true do
+    new_ac
+    new_ac
+    expect(page).to have_content('Description has already been taken')
+  end
+
+  scenario 'should show an error with blank criterions', js: true do
+    fill_in(
+      :acceptance_criterion_description,
+      with: '    '
+    )
+    find('input#save-acceptance-criterion', visible: false).trigger('click')
+    expect(page).to have_content("Description can't be blank")
   end
 end

--- a/spec/features/project/constraints/create_constraint_spec.rb
+++ b/spec/features/project/constraints/create_constraint_spec.rb
@@ -4,7 +4,7 @@ feature 'Create a new constraint' do
   let!(:user)       { create :user }
   let!(:project)    { create :project, owner: user }
   let!(:user_story) { create :user_story, project: project }
-  let(:constraint)  { build :constraint }
+  let(:constraint)  { build :constraint, description: 'My description' }
 
   background do
     sign_in user
@@ -27,5 +27,30 @@ feature 'Create a new constraint' do
       find('input#save-constraint', visible: false).trigger('click')
     end
     expect(Constraint.count).to eq 1
+  end
+
+  def new_constraint
+    within 'form.new_constraint' do
+      fill_in(
+        :constraint_description,
+        with: 'constraint.description'
+      )
+      find('input#save-constraint', visible: false).trigger('click')
+    end
+  end
+
+  scenario 'should show an error with duplicate constraints', js: true do
+    new_constraint
+    new_constraint
+    expect(page).to have_content('Description has already been taken')
+  end
+
+  scenario 'should show an error with blank constraints', js: true do
+    fill_in(
+      :constraint_description,
+      with: '    '
+    )
+    find('input#save-constraint', visible: false).trigger('click')
+    expect(page).to have_content("Description can't be blank")
   end
 end

--- a/spec/features/project/user_story/create_user_story_spec.rb
+++ b/spec/features/project/user_story/create_user_story_spec.rb
@@ -32,6 +32,16 @@ feature 'Create a new user story' do
       end
     end
 
+    scenario 'should show an error with empty fields' do
+      within 'form.new_user_story' do
+        fill_in :user_story_role, with: user_story.role
+        fill_in :user_story_action, with: '  '
+        fill_in :user_story_result, with: user_story.result
+        click_button 'Save'
+      end
+      expect(page).to have_content("Action can't be blank")
+    end
+
     scenario 'should create a new user story without duplicate' do
       create :hypothesis, { project: project }
       visit project_hypotheses_path project


### PR DESCRIPTION
## Fixes bug related to json responses on invalid entries
#### Trello board reference:
- [Trello Card #188](https://trello.com/c/9gE5qZHU/188-188-bug-fix-error-response-on-user-story-components-on-the-backlog)

---
#### Description:
- When entering a blank or duplicate element the error message wasn't being shown and page needed to be refreshed. Error was on constraints, AC and user stories.

---
#### Risk:
- Low

---
