### PR TITLE
Show the number of attachments in the sidebar link.

### DIFF
--- a/app/views/layouts/_sidebar.haml
+++ b/app/views/layouts/_sidebar.haml
@@ -39,9 +39,9 @@
         %li
           = t('sidebar.extras')
         %li
-          = link_to project_attachments_path current_project, title: "#{current_project.name} Files" do
+          = link_to project_attachments_path(current_project), id: 'attachments', title: "#{current_project.name} Files" do
             = render 'shareable/svg/files_icon'
-            = t('sidebar.files')
+            = "#{t('sidebar.files')} (#{current_project.attachments.count})"
         %li
           = link_to current_project, title: "#{current_project.name} Members" do
             = render 'shareable/svg/members_icon'

--- a/spec/features/project/attachments/create_spec.rb
+++ b/spec/features/project/attachments/create_spec.rb
@@ -60,4 +60,16 @@ feature 'Create a new attachment' do
       let(:thumbnail_name) { 'default_file_thumbnail.jpg' }
     end
   end
+
+  context 'sidebar' do
+    scenario 'should show the number of attachments in the sidebar' do
+      expect(find('#sidebar a#attachments').text).to eq 'Files (0)'
+      create_list :link_attachment, 2, project: project
+      create_list :file_attachment, 3, project: project
+
+      visit current_path
+
+      expect(find('#sidebar a#attachments').text). to eq 'Files (5)'
+    end
+  end
 end


### PR DESCRIPTION
## Show the number of attachments in the sidebar link.
#### Trello board reference:
- [Trello Card #182](https://trello.com/c/XvpNk0E4/182-as-a-user-i-should-see-how-many-files-have-been-uploaded-to-the-project-on-the-nav-bar)

---
#### Description:
- The user is able to see the number of a project's attachments in the sidebar link to the files section.

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
