### PR TITLE
Add overflow hidden and scroll to text and email so it doesnt wrap.

### DIFF
--- a/app/assets/stylesheets/_invite_members.scss
+++ b/app/assets/stylesheets/_invite_members.scss
@@ -14,15 +14,32 @@
     border-radius: $global-radius;
     height: rem-calc(45);
     margin-bottom: rem-calc(20);
-    padding: rem-calc(10 20);
+    overflow: hidden;
+    padding: rem-calc(10 0 12 20);
 
     img {
       margin-right: 10px;
       padding-bottom: rem-calc(2);
+      vertical-align: baseline;
     } // img
 
+    .user-name,
     .user-mail {
       display: inline-block;
+      height: 100%;
+      max-width: 34%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .user-mail {
+      height: rem-calc(50);
+      max-width: 55%;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      vertical-align: top;
+
 
       &::before {
         color: $success-color;

--- a/app/views/projects/show.haml
+++ b/app/views/projects/show.haml
@@ -5,7 +5,8 @@
       - @project.members.each do |member|
         .user-info
           = image_tag('icons/user-icon.svg', class: 'icon')
-          = member.full_name
+          .user-name
+            = member.full_name
           .user-mail
             = member.email
       = link_to t("project_members.edit"),'#', id: 'edit_project', class: 'button radius success small'


### PR DESCRIPTION
## long names and emails shouldn't wrap on project members page.
#### Trello board reference:
- [Trello Card #167](https://trello.com/c/jknVMl99/167-long-names-and-emails-shouldn-t-wrap-on-project-members-page)

---
#### Description:
- Add overflow property to both name and email so it doesn't wrap

---
#### Reviewers:
- @rosinanabazas 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

<img width="510" alt="screen shot 2015-10-15 at 13 25 14" src="https://cloud.githubusercontent.com/assets/6106206/10520581/4620397e-7341-11e5-9017-8a541381cd61.png">
