### PR TITLE
Bug/149/fix autosave

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :test do
   gem 'rspec-wait'
   gem 'webmock'
   gem 'vcr'
+  gem 'waiting_rspec_matchers'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,8 @@ GEM
       parser (~> 2.2.2)
       procto (~> 0.0.2)
     vcr (2.9.3)
+    waiting_rspec_matchers (0.3)
+      rspec-expectations (~> 3.0)
     warden (1.2.3)
       rack (>= 1.0)
     webmock (1.21.0)
@@ -426,4 +428,5 @@ DEPENDENCIES
   thin
   uglifier (>= 1.3.0)
   vcr
+  waiting_rspec_matchers
   webmock

--- a/app/assets/javascripts/hypotheses/userStory.js
+++ b/app/assets/javascripts/hypotheses/userStory.js
@@ -94,10 +94,10 @@ function UserStory() {
   }
 
   function bindEpicCheckbox() {
-    $epicCheckbox = $('.user-story-input.epic');
+    $epicCheckbox = $('.user-story-input.epic input:checkbox');
 
-    $epicCheckbox.change(function() {
-      var $editForm = $(this).parent();
+    $epicCheckbox.click(function() {
+      var $editForm = $(this).closest('form.edit-story');
       $editForm.submit();
     });
   }

--- a/spec/features/project/user_story/edit_user_story_spec.rb
+++ b/spec/features/project/user_story/edit_user_story_spec.rb
@@ -33,12 +33,27 @@ feature 'Edit an user story' do
 
     scenario 'should save when checking epic', js: true do
       visit project_hypotheses_path project
-      within 'form.edit_user_story' do
-        debugger
-        first('.user-story-input.epic input', visible:false).trigger('click')
-        visit current_path
+
+      within "form#edit_user_story_#{user_story.id}" do
+        all('.user-story-input.epic input', visible: false).find do |input|
+          input[:type] == 'checkbox'
+        end.trigger('click')
       end
-      expect(user_story.epic).to be_truthy
+
+      expect { user_story.reload.epic }.to become_eq true
+    end
+
+    scenario 'should save when unchecking epic', js: true do
+      user_story.update_attribute(:epic, true)
+      visit project_hypotheses_path project
+
+      within "form#edit_user_story_#{user_story.id}" do
+        all('.user-story-input.epic input', visible: false).find do |input|
+          input[:type] == 'checkbox'
+        end.trigger('click')
+      end
+
+      expect { user_story.reload.epic }.to become_eq false
     end
 
     scenario 'should be able to edit an user_story on lab section' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ Spork.prefork do
     config.include Capybara::Auth::Helpers, type: :feature
     config.include UserStoryHelper, type: :controller
     config.include UserStoryHelper, type: :feature
+    config.include WaitingRspecMatchers
 
     config.before :suite do
       DatabaseRewinder.clean_with :truncation

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,6 +1,6 @@
 module WaitForAjax
   def wait_for_ajax
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
     end
   end


### PR DESCRIPTION
## Fix autocommit on checking/unchecking epic checkbox for user stories in lab section
#### Trello board reference:
- [Trello Card #149](https://trello.com/c/CDJkwqBF/149-149-bug-if-i-created-a-story-and-then-select-it-as-epic-if-i-go-check-another-story-in-the-list-and-come-back-the-epic-checkbox-)

---
#### Description:
- If I created a story and then select it as epic, if I go check another story in the list and come back, the epic checkbox is no longer marked

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
