### PR TITLE
Copy user stories feature 

### DIFF
--- a/app/assets/images/icons/copy-icon.svg
+++ b/app/assets/images/icons/copy-icon.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 33.1 33" style="enable-background:new 0 0 33.1 33;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4FBA6F;}
+	.st1{fill:#292C38;}
+</style>
+<g id="XMLID_23_">
+	<path id="XMLID_14_" class="st0" d="M30.6,21.6h-4v-4c0-1.1-0.9-2-2-2s-2,0.9-2,2v4h-4c-1.1,0-2,0.9-2,2s0.9,2,2,2h4v4
+		c0,1.1,0.9,2,2,2s2-0.9,2-2v-4h4c1.1,0,2-0.9,2-2S31.7,21.6,30.6,21.6z"/>
+	<g id="XMLID_5_">
+		<path id="XMLID_13_" class="st1" d="M12.6,32.6h-5c-3.9,0-7-3.1-7-7v-18c0-3.9,3.1-7,7-7h18c3.9,0,7,3.1,7,7c0,1.1-0.9,2-2,2
+			s-2-0.9-2-2c0-1.7-1.3-3-3-3h-18c-1.7,0-3,1.3-3,3v18c0,1.7,1.3,3,3,3h5c1.1,0,2,0.9,2,2S13.7,32.6,12.6,32.6z"/>
+	</g>
+	<g id="XMLID_4_">
+		<path id="XMLID_12_" class="st1" d="M10.6,25.6h-1c-1.1,0-2-0.9-2-2s0.9-2,2-2h1c1.1,0,2,0.9,2,2S11.7,25.6,10.6,25.6z"/>
+	</g>
+	<g id="XMLID_3_">
+		<path id="XMLID_11_" class="st1" d="M17.6,18.6h-8c-1.1,0-2-0.9-2-2s0.9-2,2-2h8c1.1,0,2,0.9,2,2S18.7,18.6,17.6,18.6z"/>
+	</g>
+	<g id="XMLID_2_">
+		<path id="XMLID_10_" class="st1" d="M23.6,11.6h-14c-1.1,0-2-0.9-2-2s0.9-2,2-2h14c1.1,0,2,0.9,2,2S24.7,11.6,23.6,11.6z"/>
+	</g>
+</g>
+</svg>

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -265,20 +265,6 @@
       padding-top: rem-calc(20);
     }
 
-    .estimation,
-    .priority {
-      padding: 0;
-
-      select {
-        background-color: $white;
-        border-radius: $global-radius;
-        color: $black-70;
-        font-size: rem-calc(12);
-        padding-left: rem-calc(15);
-        text-transform: uppercase;
-      }
-    }
-
     .constraint-input { width: 70%; }
 
     .acceptance-criterion-form,
@@ -344,6 +330,21 @@
 
 .user-story-component-error { display: none; }
 
+.estimation,
+.priority,
+.destination-select {
+  padding: 0;
+
+  select {
+    background-color: $white;
+    border-radius: $global-radius;
+    color: $black-70;
+    font-size: rem-calc(12);
+    padding-left: rem-calc(15);
+    text-transform: uppercase;
+  }
+}
+
 .user-stories-preloader {
   display: none;
   padding-left: rem-calc(172);
@@ -355,14 +356,29 @@
   }//user-stories-preloader img
 }
 
-.new-icon { padding-bottom: rem-calc(2); }
-.copy-stories-lnk { display: none; }
-.copy-story-check-box { display: none; }
-.copy-stories-modal { max-width: 31.5rem; }
-.copy-stories-error { display: none;}
-.copy-stories-success { display: none;}
+// --------------------------------------------------------
+// COPY USER STORIES
+// --------------------------------------------------------
 
-.some-air {
-  padding-bottom: 25px;
-  padding-top: 25px;
+.copy-stories-lnk,
+.copy-story-check-box,
+.copy-stories-error,
+.copy-stories-success { display: none; }
+
+.new-icon { padding-bottom: rem-calc(2); }
+
+.copy-stories-modal {
+  max-width: 35%;
+  padding-bottom: rem-calc(40);
+
+  @media #{$small-only} { max-width: none; }
+
+  .close-reveal-modal {
+    font-size: rem-calc(20);
+    right: rem-calc(14);
+  }
+
+  .uppercase-subtitle { margin: rem-calc(15 0 5 0); }
 }
+
+.copy-story-check-box { line-height: 1; }

--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -327,6 +327,8 @@
     position: absolute;
     top: rem-calc(14);
 
+    input { display: none; }
+
     span {
       @include opacity(0);
       color: $lab-color;
@@ -334,56 +336,6 @@
       left: rem-calc(-38);
       text-transform: uppercase;
       top: rem-calc(-6);
-    }
-
-    input {
-      display: none;
-
-      +label {
-        cursor: pointer;
-        font-size: rem-calc(4);
-        margin: 0;
-        padding: 0;
-        position: relative;
-        vertical-align: top;
-        width: rem-calc(22);
-
-        &::before {
-          @include transition(background-color .25s ease-in, border-color .25s ease-in);
-          @include border-radius(rem-calc(2));
-          border: 2px solid $lab-color;
-          content: '';
-          height: rem-calc(12);
-          left: 0;
-          position: absolute;
-          top: 0;
-          width: rem-calc(12);
-        }
-
-        &::after {
-          @include transition(all .2s);
-          @include opacity(0);
-          @include scale(0);
-          color: $white;
-          content: '✔';
-          font-size: rem-calc(4);
-          left: rem-calc(4);
-          line-height: 0;
-          position: absolute;
-          top: rem-calc(7);
-        }
-      }
-
-      &:checked + label {
-        &::after {
-          @include opacity(1);
-          @include scale(1.8, 2);
-        }
-
-        &::before { background-color: $lab-color; }
-      }
-
-      &:checked:disabled + label:after { color: $black-70; }
     }
   }
 }// hypothesis item

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -66,7 +66,10 @@ select { outline: 0; }
   }
 }
 
-.icon { width: rem-calc(16); }
+.icon {
+  margin-bottom: rem-calc(2);
+  width: rem-calc(16);
+}
 
 input {
   @include input-placeholder {
@@ -122,3 +125,66 @@ input[type="password"] {
 }
 
 .alert-box.warning { background-color: $success-color; }
+
+.uppercase-subtitle {
+  color: $black-30;
+  font-size: rem-calc(12);
+  text-transform: uppercase;
+}
+
+// custom checkbox
+
+.custom-checkbox {
+  display: block;
+
+  input {
+    display: none;
+
+    +label {
+      cursor: pointer;
+      font-size: rem-calc(4);
+      margin: 0;
+      padding: 0;
+      position: relative;
+      vertical-align: top;
+      width: rem-calc(22);
+
+
+      &::before {
+        @include transition(background-color .25s ease-in, border-color .25s ease-in);
+        @include border-radius(rem-calc(2));
+        border: 2px solid $lab-color;
+        content: '';
+        height: rem-calc(12);
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: rem-calc(12);
+      }
+
+      &::after {
+        @include transition(all .2s);
+        @include opacity(0);
+        @include scale(0);
+        color: $white;
+        content: '✔';
+        font-size: rem-calc(4);
+        left: rem-calc(4);
+        line-height: 0;
+        position: absolute;
+        top: rem-calc(7);
+      }
+    } // label
+
+    &:checked + label:after {
+      @include opacity(1);
+      @include scale(2);
+    }
+
+    &:checked + label {
+      &::before { background-color: $lab-color; }
+    }
+
+    &:checked:disabled + label:after { color: $black-70; }
+ } // input
+} // custom check box

--- a/app/views/user_stories/_backlog_list.haml
+++ b/app/views/user_stories/_backlog_list.haml
@@ -10,8 +10,9 @@
             = link_to user_story_path(user_story), title: t('backlog.user_stories.delete'), class: 'trash-btn center-icon delete-story', method: :delete do
               %span.icon-trash
           %span.icon-arrow.down{ title: t('backlog.user_stories.rearrange') }
-        .copy-story-check-box
+        .custom-checkbox.copy-story-check-box
           = check_box_tag "user_story_#{user_story.id}", user_story.id
+          %label{ for: "user_story_#{user_story.id}" }
         .number
           = "##{user_story.story_number}"
         %span.points

--- a/app/views/user_stories/_copy_stories_modal.haml
+++ b/app/views/user_stories/_copy_stories_modal.haml
@@ -1,12 +1,12 @@
-#copy_stories_modal.copy-stories-modal.reveal-modal{ aria: { hidden: true, labelledby: 'copy-stories-modal-title' }, data: { reveal: '', role: 'dialog' } }
-  %h2#copy-stories-modal-title=t('backlog.user_stories.copy_stories')
-  %a.close-reveal-modal{ aria: { label: 'Close' } }×
-  .row.some-air
+.row
+  #copy_stories_modal.copy-stories-modal.reveal-modal.large-4.columns{ aria: { hidden: true, labelledby: 'copy-stories-modal-title' }, data: { reveal: '', role: 'dialog' } }
+    %h2#copy-stories-modal-title=t('backlog.user_stories.copy_stories')
+    %a.close-reveal-modal{ aria: { label: 'Close' } }×
     .alert-box.error.copy-stories-error
       = t('backlog.user_stories.no_stories')
-  .row.some-air
-    .medium-10.medium-offset-1.columns
+    .uppercase-subtitle= t('backlog.user_stories.destination_project')
+    .destination-select
       = select_tag 'copy_story_project_id', options_from_collection_for_select(projects, 'id', 'name')
-      = button_tag t('backlog.user_stories.copy_stories'), class: 'button radius small success',
-      id: 'copy_stories_submit', data: { url: user_stories_copy_path }
-= javascript_include_tag 'userStories/copyModal'
+    = button_tag t('backlog.user_stories.copy_stories'), class: 'button radius small success',
+    id: 'copy_stories_submit', data: { url: user_stories_copy_path }
+  = javascript_include_tag 'userStories/copyModal'

--- a/app/views/user_stories/_lab_form.haml
+++ b/app/views/user_stories/_lab_form.haml
@@ -8,7 +8,7 @@ url: form_url do |form|
         - user_story.errors.full_messages.each do |error|
           %li= error
   %span.icon-edit
-  .user-story-input.epic
+  .custom-checkbox.user-story-input.epic
     = form.check_box :epic, id: user_story.id
     %label{ for: user_story.id }
     %span= t('backlog.user_stories.epic')

--- a/app/views/user_stories/index.haml
+++ b/app/views/user_stories/index.haml
@@ -10,10 +10,10 @@
     = t('backlog.user_stories.new')
   - if @project.user_stories.any?
     = link_to '#', class: "nav-links", id: 'select_stories_lnk' do
-      = image_tag('icons/add-icon.svg', class: 'icon')
+      = image_tag('icons/copy-icon.svg', class: 'icon')
       = t('backlog.user_stories.select_to_copy')
     = link_to '#', class: "nav-links copy-stories-lnk", id: 'copy_stories_lnk', data: { reveal_id: 'copy_stories_modal' } do
-      = image_tag('icons/add-icon.svg', class: 'icon')
+      = image_tag('icons/copy-icon.svg', class: 'icon')
       = t('backlog.user_stories.copy_stories')
   %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
     %li#csv_export_link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,7 @@ en:
       no_stories: "There are not stories selected to be copied."
       stories_copied: "The stories are copied successfully."
       new_tag: 'Create a new tag here'
+      destination_project: "Select destination project"
     story_span: "Story"
     logout: "Sign out"
     acceptance_criteria: "Acceptance Criteria"

--- a/spec/features/project/user_story/copy_spec.rb
+++ b/spec/features/project/user_story/copy_spec.rb
@@ -29,7 +29,7 @@ feature 'Copy project', js: true do
     end
 
     within '.copy-story-check-box' do
-      check "user_story_#{@user_story.id}"
+      find("#user_story_#{@user_story.id}", visible: false).trigger(:click)
     end
 
     within '#top-nav' do


### PR DESCRIPTION
## Style copy mode feature on Backlog
#### Trello board reference:
- [Trello Card #116](https://trello.com/c/Jb1yzmNX/116-116-as-a-user-i-must-be-able-to-select-one-or-many-user-stories-to-be-copied-to-an-existing-project)

---
#### Description:
- Added custom checkbox styles to Backlog's copy mode and also fixed foundation classes to style copy modal.

---
#### Reviewers:
## \* @doshii 
#### Tasks:
- [x] Style  checkboxes on copy mode 
- [x] Style modal to save and copy stories
- [x] Refactor checkboxes css in order to have a new general class for them

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/10517851/2c18ccf0-7335-11e5-813d-a50c2d5997e5.gif)
