### PR TITLE
Remove padding left on medium screens.

### DIFF
--- a/app/assets/stylesheets/_canvas.scss
+++ b/app/assets/stylesheets/_canvas.scss
@@ -53,6 +53,7 @@
     padding-left: rem-calc(40);
 
     @media #{$small-only} { padding-left: 0; }
+    @media #{$medium-only} { padding-left: 0; }
 
     .canvas-fields {
       @include opacity(0);


### PR DESCRIPTION
## Margin not being removed when shrinking dimensions for "What are the top three problems that you are trying to solve?"
#### Trello board reference:
- [Trello Card #144](https://trello.com/c/2qcDwrZN/144-margin-not-being-removed-when-shrinking-dimensions-for-what-are-the-top-three-problems-that-you-are-trying-to-solve-section-scre)

---
#### Description:
- Remove padding on medium screens to clear empty pace on left.

---
#### Reviewers:
- @rosinanabazas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

<img width="761" alt="screen shot 2015-10-15 at 13 57 56" src="https://cloud.githubusercontent.com/assets/6106206/10521204/e08c284e-7344-11e5-96e9-da051ec54bce.png">
