### PR TITLE
Remove overfow hidden on body

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -2,10 +2,6 @@
 // MAIN STYLES
 // --------------------------------------------------------
 
-body {
-  overflow: hidden;
-}
-
 .right-app-content {
   height: 100%;
   overflow-y: scroll;


### PR DESCRIPTION
## Scroll issue
#### Trello board reference:
- [Trello Card #154](https://trello.com/c/AmJWC4M8/154-i-use-google-chrome-for-mac-with-a-password-management-extension-called-lastpass-when-i-clicked-the-lastpass-password-generation)

---
#### Description:
- Remove the overflow hidden on body to let the user scroll when needed

---
#### Reviewers:
- @rosinanabazas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Medium

---
