### PR TITLE
Add text wrapp property to handle long project names.

### DIFF
--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -57,6 +57,7 @@
         color: inherit;
         display: block;
         font-size: rem-calc(15);
+        max-width: 90%;
         padding: rem-calc(10 0);
 
         &:hover,
@@ -67,7 +68,12 @@
         +a { display: inline; }
 
         &.my-projects,
-        &.current-project { @include transition(color .25s ease-in, opacity .25s ease-in .25s); }
+        &.current-project {
+          @include transition(color .25s ease-in, opacity .25s ease-in .25s);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       }
 
       .canvas .bullet::before  { color: $canvas-color; }
@@ -297,5 +303,3 @@
 
   &.full { width: calc(100% - 4.0625rem); }
 }
-
-


### PR DESCRIPTION
## If the Project's title is too long, it overlaps with the icon next to it
#### Trello board reference:
- [Trello Card #173](https://trello.com/c/atddDEpR/173-if-the-project-s-title-is-too-long-it-overlaps-with-the-icon-next-to-it)

---
#### Description:
- Add overflow ellipsis to project titles so it doesn't mess on the sidebar

---
#### Reviewers:
- @rosinanabazas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

<img width="237" alt="screen shot 2015-10-15 at 17 10 33" src="https://cloud.githubusercontent.com/assets/6106206/10526434/390f0c4a-7361-11e5-88d6-ffcd4a37187e.png">
<img width="233" alt="screen shot 2015-10-15 at 17 10 41" src="https://cloud.githubusercontent.com/assets/6106206/10526437/3c659be8-7361-11e5-8f1e-39e1f391eaa3.png">
