### PR TITLE
Link attachments now open in a new tab when you click on the link.

### DIFF
--- a/app/views/attachments/_show_link.haml
+++ b/app/views/attachments/_show_link.haml
@@ -3,7 +3,7 @@
     = image_tag attachment.thumbnail
   .link-info.large-10.columns
     .attachment-content
-      = link_to attachment.content, attachment.content
+      = link_to attachment.content, attachment.content, target: :blank
     .attachment-activity
       %span= t('attachment.link.name_info')
       .user-name


### PR DESCRIPTION
## When i select a file to be viewed it navigates to the file within the same browser tab rather than opening a new tab.
#### Trello board reference:
- [Trello Card #](184)

---
#### Description:
- This enables the user to open multiple links in the files section when going through the list without having them to open the links in a new tab manually.

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
