### PR TITLE
Fix button's alignment & Center thumbnail image

### DIFF
--- a/app/assets/stylesheets/_attachments.scss
+++ b/app/assets/stylesheets/_attachments.scss
@@ -26,7 +26,7 @@
 
   .button {
     margin-left: 0;
-    padding: inherit rem-calc(40);
+    padding: rem-calc(15 40);
     width: auto;
   }
 
@@ -64,7 +64,7 @@
 
       .button {
         margin-right: rem-calc(15);
-        padding: inherit rem-calc(35);
+        padding: rem-calc(15 35);
       }
     }
 
@@ -74,13 +74,19 @@
   .item-wrapper { margin: rem-calc(0 0 20); }
 
   .attachment-thumbnail {
-    img {
-      border: 1px solid $black-30;
-      height: rem-calc(90);
-      width: rem-calc(120);
-    } // thumb image
+    border: 1px solid $black-30;
+    height: rem-calc(90);
+    overflow: hidden;
+    position: relative;
+    width: rem-calc(120);
 
-    @media #{$small-only} { padding-left: 0; }
+    img {
+      @include translate(-50%, -50%);
+      left: 50%;
+      position: absolute;
+      top: 50%;
+      width: 100%;
+    }
   }
 
   .link-info {


### PR DESCRIPTION
## Files&Links view bugs
#### Trello board reference:
- [Trello Card #117](https://trello.com/c/sjQZm43m/117-117-as-a-user-i-should-be-able-to-see-a-small-thumbnail-preview-of-my-files)

---
#### Description:
- Fixes Save button alignment and Corrects thumbnail image.

---
#### Reviewers:
- @bocha

---
#### Notes:
- Patrick is going to fix thumbnail for narrow images as now they look with a white border which can't be corrected with css.

---
#### Tasks:
- [x] Deleted inherit property which wasn't working and added real paddings to button.
- [x] Added styles to div and thumbnail images so they doesn't look bad stretched anymore. Even though we still need to fix narrow ones.

---
#### Risk:
- Low

---
#### Preview:

<img width="1392" alt="screen shot 2015-10-20 at 4 48 20 p m" src="https://cloud.githubusercontent.com/assets/6147409/10619139/6b013f06-774a-11e5-84b0-a93256881f9b.png">
