### PR TITLE
Resize thumbnail images to fill.

### DIFF
--- a/app/uploaders/thumbnail_uploader.rb
+++ b/app/uploaders/thumbnail_uploader.rb
@@ -1,7 +1,7 @@
 class ThumbnailUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  process resize_to_limit: [120, 90]
+  process resize_to_fill: [120, 90]
 
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"


### PR DESCRIPTION
## Change thumbnail size of image attachments
#### Trello board reference:
- [Trello Card #117](https://trello.com/c/sjQZm43m/117-117-as-a-user-i-should-be-able-to-see-a-small-thumbnail-preview-of-my-files)

---
#### Description:
- This PR changes the thumbnail size approach from resize_to_fill to resize_to_fit which means that the image is centered and cropped in the bigger dimension.

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
