### PR TITLE
Correct sidebar's arrows direction

### DIFF
--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -213,10 +213,9 @@
   }
 
   .icon-arrow {
-    @include rotate(180deg);
     @include transition(transform .25s ease-in, color .25s ease-in);
 
-    &.active { @include rotate(0); }
+    &.active { @include rotate(180deg); }
   }
 
   .arbor-version {


### PR DESCRIPTION
## Correct sidebar's arrows direction
#### Trello board reference:
- [Trello Card #](https://trello.com/c/MihfX1hq/145-the-logic-for-the-arrow-that-indicates-whether-the-project-list-is-opened-or-closed-is-backwards)

---
#### Description:
- Sidebar's arrows which indicates whether the project list is opened or closed was backwards.

---
#### Reviewers:
- @bocha

---
#### Tasks:
- [x] Move rotate(180deg) property to active state.

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/10639328/f73ce3b2-77e5-11e5-8cdf-38df8b28eeec.gif)
