### PR TITLE
Fix the problem that file attachments did not open in a new tab.

### DIFF
--- a/app/views/attachments/_show_file.haml
+++ b/app/views/attachments/_show_file.haml
@@ -3,7 +3,7 @@
     = image_tag attachment.thumbnail
   .link-info.large-10.columns
     .attachment-content
-      = link_to attachment.content.file.filename, attachment.content.url
+      = link_to attachment.content.file.filename, attachment.content.url, target: :blank
     .attachment-activity
       %span= t('attachment.link.name_info')
       .user-name


### PR DESCRIPTION
## File attachments were not opened in a new tab
#### Trello board reference:
- [Trello Card #184](https://trello.com/c/L11TBpTG/184-when-i-select-a-file-to-be-viewed-it-navigates-to-the-file-within-the-same-browser-tab-rather-than-opening-a-new-tab)

---
#### Description:
- This PR addresses the issue that file attachments were not opened in a new tab when I clicked on them in the files section.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
