### PR TITLE
Fix bug when unchecking last checkbox

### DIFF
--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -27,7 +27,7 @@ class UserStoriesController < ApplicationController
 
   def update
     respond_to do |format|
-      @user_story.update_attributes(user_story_params)
+      @user_story.update_attributes(story_update_params)
       format.json do
         json_update
       end
@@ -59,6 +59,12 @@ class UserStoriesController < ApplicationController
   end
 
   private
+
+  def story_update_params
+    params = user_story_params
+    params[:tag_ids] ||= []
+    params
+  end
 
   def export_content
     debug = params.key?('debug')


### PR DESCRIPTION
## Fix bug when unchecking last checkbox on user stories
#### Trello board reference:
- [Trello Card #112](https://trello.com/c/vHScBUfU/112-112-as-a-user-i-should-be-able-to-tag-a-user-story)

---
#### Description:
- When unchecking a checkbox, If there are no other checkboxes checked, the param 'tag_ids' is not even sent from the view, so when updating the user story attributes it wouldn't change the tags associated to it. Add a method to include the empty 'tag_ids' array in this case.

---
#### Reviewers:
- @patrickschulze 

---
#### Risk:
- Low

---
