### PR TITLE
Users are not allowed to delete hypotheses with user stories.

### DIFF
--- a/app/controllers/hypotheses_controller.rb
+++ b/app/controllers/hypotheses_controller.rb
@@ -33,7 +33,11 @@ class HypothesesController < ApplicationController
   end
 
   def destroy
-    @project.hypotheses.destroy(@hypothesis)
+    if @hypothesis.user_stories.any?
+      flash[:alert] = I18n.t('labs.hypotheses.delete_with_stories')
+    else
+      @project.hypotheses.destroy(@hypothesis)
+    end
 
     redirect_to project_hypotheses_path(@project)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
       enter_description: "Write a new hypothesis"
       export: "Export"
       select_metric: 'Select a success metric'
+      delete_with_stories: 'You are not allowed to delete hypotheses with assigned user stories'
     goals:
       title: "Title"
       enter_title: "Enter Title"


### PR DESCRIPTION
## Don't delete hypotheses with associated user stories.
#### Trello board reference:
- [Trello Card #171](https://trello.com/c/g2Hw8lba/171-171-lab-i-cannot-add-another-user-story-or-move-the-existing-user-story-from-the-undefined-hypothesis)

---
#### Description:
- You shouldn't be able to delete an undefined hypothesis if there are user stories underneath it.
  This is a feedback to card #171.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- 

---
#### Preview:
- N/A
