### PR TITLE
Added minimum password length to signup form.

### DIFF
--- a/app/assets/stylesheets/_signin.scss
+++ b/app/assets/stylesheets/_signin.scss
@@ -8,6 +8,10 @@
     vertical-align: middle;
   }
 
+  .password-information {
+    color: $black-30;
+  }
+
   .forgot-password {
     color: $black-40;
     display: block;

--- a/app/views/devise/registrations/_sign_up.haml
+++ b/app/views/devise/registrations/_sign_up.haml
@@ -10,6 +10,8 @@
     .field
       = image_tag('icons/password-icon.svg', class: 'icon')
       = f.password_field :password, placeholder: t('sign_up.password'), class: 'with-icon radius', autocomplete: 'off', required: true
+      .password-information
+        = t('sign_up.password_length', length: resource.class.password_length.min)
     .field
       = image_tag('icons/password-icon.svg', class: 'icon')
       = f.password_field :password_confirmation, autocomplete: 'off', placeholder: t('sign_up.password_confirmation') , class: 'with-icon radius',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     password: "Password"
     password_confirmation: "Password confirmation"
     button_signup: "Sign up"
+    password_length: "Minimum %{length} characters"
   login:
     title: "Login"
     password: "Password"

--- a/spec/features/landing_page/signup_spec.rb
+++ b/spec/features/landing_page/signup_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 feature 'Sign up to Arbor' do
   let(:user) { build :user }
 
-  scenario 'when I enter all credentials correctly I can sign up' do
+  scenario 'should show me the minimum password length when I enter' do
+    visit new_user_session_path
+
+    expect(page).to have_content 'Minimum 8 characters'
+  end
+
+  scenario 'should sign me up when I enter all credentials correctly' do
     visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
@@ -17,7 +23,7 @@ feature 'Sign up to Arbor' do
     expect(page).to have_content 'Welcome! You have signed up successfully.'
   end
 
-  scenario 'When I enter mismatching passwords I should get an error' do
+  scenario 'should show me an error when I enter mismatching passwords' do
     visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
@@ -31,7 +37,7 @@ feature 'Sign up to Arbor' do
     expect(page).to have_content "Password confirmation doesn't match Password"
   end
 
-  scenario 'When I enter too short passwords I should get an error' do
+  scenario 'should show me an error when I enter too short passwords' do
     visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name


### PR DESCRIPTION
## Inform user about password requirements
#### Trello board reference:
- [Trello Card #208](https://trello.com/c/DkOU48LR/208-as-a-user-i-should-be-able-to-know-the-minimum-of-8-characters-requirement-for-passwords-so-that-when-i-m-signing-up-for-arbor-m)

---
#### Description:
- The user is now informed about the password requirements when signing up for Arbor.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- 

---
#### Preview:
- N/A
