### PR TITLE
Style Password's minimum characters text

### DIFF
--- a/app/assets/stylesheets/_signin.scss
+++ b/app/assets/stylesheets/_signin.scss
@@ -10,6 +10,8 @@
 
   .password-information {
     color: $black-30;
+    font-size: rem-calc(13);
+    padding-bottom: rem-calc(10);
   }
 
   .forgot-password {
@@ -18,6 +20,8 @@
     text-decoration: underline;
   } // centered links
 } // section intro
+
+.password-input input { margin-bottom: rem-calc(5); }
 
 .password-length { color: $black-50; }
 

--- a/app/views/devise/registrations/_sign_up.haml
+++ b/app/views/devise/registrations/_sign_up.haml
@@ -7,7 +7,7 @@
     .field
       = image_tag('icons/mail-icon.svg', class: 'icon')
       = f.email_field :email, autofocus: true, required: true, placeholder: t('sign_up.mail'), class: 'with-icon radius'
-    .field
+    .field.password-input
       = image_tag('icons/password-icon.svg', class: 'icon')
       = f.password_field :password, placeholder: t('sign_up.password'), class: 'with-icon radius', autocomplete: 'off', required: true
       .password-information

--- a/app/views/devise/sessions/_login.haml
+++ b/app/views/devise/sessions/_login.haml
@@ -4,7 +4,7 @@
     .field
       = image_tag('icons/mail-icon.svg', class: 'icon')
       = f.email_field :email, autofocus: true, required: true, placeholder: t('login.email'), class: 'with-icon radius login'
-    .field
+    .field.password-input
       = image_tag('icons/password-icon.svg', class: 'icon')
       = f.password_field :password, placeholder: t('login.password'), class: 'with-icon radius login', autocomplete: 'off', required: true
     - if devise_mapping.rememberable?


### PR DESCRIPTION
## Style password's minimum characters text on Sign up form
#### Trello board reference:
- [Trello Card #](https://trello.com/c/DkOU48LR/208-as-a-user-i-should-be-able-to-know-the-minimum-of-8-characters-requirement-for-passwords-so-that-when-i-m-signing-up-for-arbor-m)

---
#### Reviewers:
- @Bocha

---
#### Tasks:
- [x] Change text's font size
- [x] Reduce input's margin bottom

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-10-26 at 4 27 23 p m](https://cloud.githubusercontent.com/assets/6147409/10740011/8091c36e-7bfe-11e5-900c-451c170b21e9.png)
