### PR TITLE
Remove epic feature.

### DIFF
--- a/app/assets/javascripts/hypotheses/userStory.js
+++ b/app/assets/javascripts/hypotheses/userStory.js
@@ -86,19 +86,9 @@ function UserStory() {
         showHypothesis(hypothesisId);
 
         bindUserStoriesSortEvent();
-        bindEpicCheckbox();
 
         var $userStoryForm = $('#edit_user_story_' + userStoryId);
         $appContent.scrollTo($userStoryForm, 200);
-    });
-  }
-
-  function bindEpicCheckbox() {
-    $epicCheckbox = $('.user-story-input.epic input:checkbox');
-
-    $epicCheckbox.click(function() {
-      var $editForm = $(this).closest('form.edit-story');
-      $editForm.submit();
     });
   }
 
@@ -114,7 +104,6 @@ function UserStory() {
     });
   }
 
-  bindEpicCheckbox();
   bindUserStoriesSortEvent();
 
   $newUserStoryForm.submit(function() {

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -309,25 +309,6 @@
       width: 100%;
     }
 
-    .epic {
-      line-height: .4;
-      padding: rem-calc(0 0 20);
-
-      input {
-        cursor: pointer;
-        float: left;
-        margin: rem-calc(1 8 0 0);
-        width: auto;
-      }
-
-      label {
-        color: $lab-color;
-        font-size: rem-calc(12);
-        vertical-align: baseline;
-        width: auto;
-      }
-    }  // epic
-
     .estimation { padding-right: rem-calc(15); }
   } // user story edit form
 } // backlog

--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -149,9 +149,7 @@
 
     &.editing {
       .enter { display: inline-block; }
-      .epic span { @include opacity(1); }
       .user-story-input { font-weight: $font-weight-bold; }
-      .new-story .epic label::before { border-color: $lab-color; }
     }
   }
 
@@ -212,13 +210,6 @@
 
     &.ui-sortable-helper {
       padding: rem-calc(0 20 0 40);
-
-      .epic {
-        left: rem-calc(10);
-
-        span { @include opacity(0); }
-      }
-
       .icon-trash { right: rem-calc(10); }
     }
 
@@ -227,13 +218,6 @@
       input,
       .user-story-input {
         color: $canvas-color;
-
-        &.epic input:checked +label::before {
-          background-color: $canvas-color;
-          border-color: $canvas-color;
-        }
-
-        &.epic input +label::before { border-color: $canvas-color; }
       }
     }
 
@@ -247,11 +231,6 @@
     .new-story {
       @include clearfix;
       padding: rem-calc(8 0);
-    }
-
-    .new-story .epic label::before {
-      @include grab-cursor;
-      border-color: $font-color-3;
     }
 
     .user-story-input {
@@ -320,23 +299,6 @@
     float: right;
     font-size: rem-calc(16);
     margin-top: 0;
-  }
-
-  .epic {
-    left: rem-calc(1);
-    position: absolute;
-    top: rem-calc(14);
-
-    input { display: none; }
-
-    span {
-      @include opacity(0);
-      color: $lab-color;
-      font-weight: $font-weight-normal;
-      left: rem-calc(-38);
-      text-transform: uppercase;
-      top: rem-calc(-6);
-    }
   }
 }// hypothesis item
 

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -131,7 +131,7 @@ class UserStoriesController < ApplicationController
   def user_story_params
     params.require(:user_story).permit(
       :role, :action, :result, :estimated_points,
-      :priority, :hypothesis_id, :epic, tag_ids: []
+      :priority, :hypothesis_id, tag_ids: []
     )
   end
 

--- a/app/views/user_stories/_form.haml
+++ b/app/views/user_stories/_form.haml
@@ -58,10 +58,6 @@
     = form.hidden_field :hypothesis_id, value: hypothesis.id
   = form.submit I18n.translate('save'), class: 'hide user-story-submit'
   .row
-    .user-story-input.epic.large-12.columns
-      %label
-        = t('backlog.user_stories.epic')
-        = form.check_box :epic, id: user_story.id
     - if user_story.project
       .uppercase-subtitle.criterion-group= t('backlog.tags')
       - user_story.project.tags.each do |tag|

--- a/app/views/user_stories/_lab_form.haml
+++ b/app/views/user_stories/_lab_form.haml
@@ -7,11 +7,7 @@ url: form_url do |form|
       %ul
         - user_story.errors.full_messages.each do |error|
           %li= error
-  %span.icon-edit
-  .custom-checkbox.user-story-input.epic
-    = form.check_box :epic, id: user_story.id
-    %label{ for: user_story.id }
-    %span= t('backlog.user_stories.epic')
+  %span
   .user-story-input.role
     = t('backlog.user_stories.role')
     = form.text_field(                                   |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,6 @@ en:
       rearrange: "Rearrange User Story"
       edit_title: "Edit User Story"
       new: "New user story"
-      epic: "epic"
       enter_criterion: 'Write a new acceptance criterion here...'
       enter_constraint: "Write a new constraint here..."
       edit_role: "Edit type of user"

--- a/db/migrate/20151026181159_remove_epic_from_user_story.rb
+++ b/db/migrate/20151026181159_remove_epic_from_user_story.rb
@@ -1,0 +1,5 @@
+class RemoveEpicFromUserStory < ActiveRecord::Migration
+  def change
+    remove_column :user_stories, :epic, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013142834) do
+ActiveRecord::Schema.define(version: 20151026181159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,7 +175,6 @@ ActiveRecord::Schema.define(version: 20151013142834) do
     t.integer  "order"
     t.integer  "story_number"
     t.integer  "backlog_order"
-    t.boolean  "epic",                         default: false
   end
 
   add_index "user_stories", ["hypothesis_id"], name: "index_user_stories_on_hypothesis_id", using: :btree

--- a/spec/controllers/user_stories_controller_spec.rb
+++ b/spec/controllers/user_stories_controller_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe UserStoriesController do
       action: 'sign up',
       result: 'i can browse the site',
       estimated_points: '3',
-      priority: 'should',
-      epic: 'false'
+      priority: 'should'
     }
 
     it 'sends a success response with the edit url from backlog' do
@@ -28,8 +27,7 @@ RSpec.describe UserStoriesController do
           action: 'sign up',
           result: 'i can browse the database',
           estimated_points: '3',
-          priority: 'should',
-          epic: 'false'
+          priority: 'should'
         }
 
       expect(UserStory.count).to eq(1)
@@ -50,8 +48,7 @@ RSpec.describe UserStoriesController do
           result: 'i can browse the site',
           estimated_points: '3',
           priority: 'should',
-          hypothesis_id: hypothesis.id,
-          epic: 'false'
+          hypothesis_id: hypothesis.id
         }
 
       expect(UserStory.count).to eq(1)

--- a/spec/factories/user_stories.rb
+++ b/spec/factories/user_stories.rb
@@ -1,12 +1,4 @@
 FactoryGirl.define do
-  factory :epic, class: UserStory do
-    role     { 'User' }
-    action   { 'be able to log in'}
-    result   { 'so that I can use the app' }
-    project  { create :project }
-    epic     { true }
-  end
-
   factory :user_story do
     role             { 'User' }
     action           { 'be able to reset my password'}

--- a/spec/features/project/user_story/create_user_story_spec.rb
+++ b/spec/features/project/user_story/create_user_story_spec.rb
@@ -102,31 +102,6 @@ feature 'Create a new user story' do
       end
     end
 
-    scenario 'should create a new user story as a non epic' do
-      within 'form.new_user_story' do
-        fill_in :user_story_role, with: user_story.role
-        fill_in :user_story_action, with: user_story.action
-        fill_in :user_story_result, with: user_story.result
-
-        click_button 'Save'
-      end
-
-      expect(UserStory.first.epic).to be false
-    end
-
-    scenario 'should create a new user story as a an epic' do
-      within 'form.new_user_story' do
-        fill_in :user_story_role, with: user_story.role
-        fill_in :user_story_action, with: user_story.action
-        fill_in :user_story_result, with: user_story.result
-        check :epic
-
-        click_button 'Save'
-      end
-
-      expect(UserStory.first.epic).to be true
-    end
-
     scenario 'should create a new user story with another priority' do
       within 'form.new_user_story' do
         fill_in :user_story_role, with: user_story.role

--- a/spec/features/project/user_story/edit_user_story_spec.rb
+++ b/spec/features/project/user_story/edit_user_story_spec.rb
@@ -31,31 +31,6 @@ feature 'Edit an user story' do
       end
     end
 
-    scenario 'should save when checking epic', js: true do
-      visit project_hypotheses_path project
-
-      within "form#edit_user_story_#{user_story.id}" do
-        all('.user-story-input.epic input', visible: false).find do |input|
-          input[:type] == 'checkbox'
-        end.trigger('click')
-      end
-
-      expect { user_story.reload.epic }.to become_eq true
-    end
-
-    scenario 'should save when unchecking epic', js: true do
-      user_story.update_attribute(:epic, true)
-      visit project_hypotheses_path project
-
-      within "form#edit_user_story_#{user_story.id}" do
-        all('.user-story-input.epic input', visible: false).find do |input|
-          input[:type] == 'checkbox'
-        end.trigger('click')
-      end
-
-      expect { user_story.reload.epic }.to become_eq false
-    end
-
     scenario 'should be able to edit an user_story on lab section' do
       visit project_hypotheses_path project
       within 'form.edit_user_story' do

--- a/spec/services/user_story_service_spec.rb
+++ b/spec/services/user_story_service_spec.rb
@@ -9,8 +9,7 @@ feature 'update user story' do
     action: 'be able to reset my password',
     result: 'so that I can recover my account',
     estimated_points: 1,
-    priority: 'should',
-    epic: false
+    priority: 'should'
   }
 
   scenario 'should load the response' do
@@ -30,8 +29,7 @@ feature 'create user story' do
       action: 'be able to reset my password',
       result: 'so that I can recover my account',
       estimated_points: 1,
-      priority: 'should',
-      epic: false
+      priority: 'should'
     }
   }
 
@@ -46,7 +44,6 @@ feature 'create user story' do
     expect(story.result).to eq(user_story_params[:result])
     expect(story.estimated_points).to eq(user_story_params[:estimated_points])
     expect(story.priority).to eq(user_story_params[:priority])
-    expect(story.epic).to eq(user_story_params[:epic])
   end
 
   scenario 'should create a User Story and assign the project and hypothesis' do
@@ -61,7 +58,6 @@ feature 'create user story' do
     expect(story.result).to eq(user_story_params[:result])
     expect(story.estimated_points).to eq(user_story_params[:estimated_points])
     expect(story.priority).to eq(user_story_params[:priority])
-    expect(story.epic).to eq(user_story_params[:epic])
   end
 end
 


### PR DESCRIPTION
## Remove 'epic' feature from the app.
#### Trello board reference:
- [Trello Card #222](https://trello.com/c/dkQyVLSa/222-delete-epic-checkbox-feature)

---
#### Description:
- The 'epic' checkbox for user stories is no longer necessary since a tagging feature has been implemented and there can be an 'epic' tag instead.

---
#### Reviewers:
- @patrickschulze

---
#### Risk:
- Medium

---
