### PR TITLE
Reduced numbers in fibonacci estimation series to 7.

### DIFF
--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -22,7 +22,7 @@ class UserStory < ActiveRecord::Base
 
   def self.estimation_series
     fib = ->(arg) { arg < 2 ? arg : fib[arg - 1] + fib[arg - 2] }
-    (2..12).map { |index| fib[index] }.unshift([nil])
+    (2..8).map { |index| fib[index] }.unshift([nil]).flatten
   end
 
   def log_description

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -60,4 +60,12 @@ RSpec.describe UserStory do
       expect(next_story.story_number).to eq 3
     end
   end
+
+  describe 'fibonacci series' do
+    it 'should only list the first 7 fibonacci numbers for estimation' do
+      numbers = UserStory.estimation_series
+      expect(numbers.count).to eq 8
+      expect(numbers).to eq [nil, 1, 2, 3, 5, 8, 13, 21]
+    end
+  end
 end


### PR DESCRIPTION
## Reduced numbers in fibonacci estimation series to 7.
#### Trello board reference:
- [Trello Card #218](https://trello.com/c/yq5z6pcP/218-218-reduce-the-number-of-available-fibonacci-numbers-for-the-story-estimation)

---
#### Description:
- This PR reduces the estimation series numbers so that the highest number is 21.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
