### PR TITLE
Remove successful signup message.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,7 +14,6 @@ class RegistrationsController < Devise::RegistrationsController
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
-        set_flash_message :notice, :signed_up if is_flashing_format?
         sign_up(resource_name, resource)
         respond_with resource, location: after_sign_up_path_for(resource)
       else

--- a/spec/features/landing_page/signup_spec.rb
+++ b/spec/features/landing_page/signup_spec.rb
@@ -20,7 +20,21 @@ feature 'Sign up to Arbor' do
       click_button 'Sign up'
     end
 
-    expect(page).to have_content 'Welcome! You have signed up successfully.'
+    expect(page).to have_selector '#sidebar'
+  end
+
+  scenario 'should not show me the signup successful message' do
+    visit new_user_session_path
+    within '#signup' do
+      fill_in :user_full_name, with: user.full_name
+      fill_in :user_email, with: user.email
+      fill_in :user_password, with: 'foobar123'
+      fill_in :user_password_confirmation, with: 'foobar123'
+
+      click_button 'Sign up'
+    end
+
+    expect(page).not_to have_content 'Welcome! You have signed up successfully.'
   end
 
   scenario 'should show me an error when I enter mismatching passwords' do


### PR DESCRIPTION
## Remove successful signup message.
#### Trello board reference:
- [Trello Card #91](https://trello.com/c/Qv8x0d0s/91-91-when-you-enter-a-password-shorter-than-8-characters-you-are-redirected-to-an-un-styled-form-that-is-missing-the-first-name-fi)

---
#### Description:
- This PR removes the message that you got when you successfully signed up for Arbor.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
