### PR TITLE
Hide notification alerts after a specific time 

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -185,5 +185,10 @@ $('.hypothesis input')
 
 $(document).ready(function() {
   UTIL.init();
-});
 
+  if ($('.alert-box').is(':visible')) {
+    setTimeout(function () {
+      $('.alert-box').fadeOut();
+    }, 2000);
+  }//if alert box is visible
+});


### PR DESCRIPTION
## Hide notification boxes after a specific time
#### Trello board reference:
- [Trello Card #191](https://trello.com/c/Y2fLZGa4/191-make-the-notifcation-messages-automatically-disappear-after-a-specific-time)

---
#### Description:
- Hides Notification boxes after 3 seconds they appeared.

---
#### Reviewers:
- @Bocha

---
#### Tasks:
- [x] Add js to add .hide-alert-box class 
- [x] Add display none class on css

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/10761574/c82f06e4-7ca0-11e5-8774-0fac9455f046.gif)
