### PR TITLE
Link Trello export from backlog.

### DIFF
--- a/app/views/hypotheses/index.haml
+++ b/app/views/hypotheses/index.haml
@@ -1,5 +1,5 @@
 %script{src: "http://code.jquery.com/jquery-1.7.1.min.js"}
-%script{src: "//api.trello.com/1/client.js?key=f351a7f0bd7d8b8924b22ef2677f7738"}
+%script{src: "//api.trello.com/1/client.js?key=#{ENV['TRELLO_DEVELOPER_PUBLIC_KEY']}"}
 
 - content_for :top_links do
   = link_to '#', {"aria-controls" => "drop1", "aria-expanded" => "false", id: "export-button", class: "nav-links", "data-dropdown" => "drop1"} do

--- a/app/views/user_stories/index.html.haml
+++ b/app/views/user_stories/index.html.haml
@@ -1,3 +1,6 @@
+%script{src: "http://code.jquery.com/jquery-1.7.1.min.js"}
+%script{src: "//api.trello.com/1/client.js?key=#{ENV['TRELLO_DEVELOPER_PUBLIC_KEY']}"}
+
 - content_for :top_links do
   = link_to '#', class: "nav-links" do
     = image_tag('icons/search-icon.svg', class: 'icon')
@@ -18,6 +21,8 @@
   %ul#drop1.f-dropdown{"aria-hidden" => "true", "data-dropdown-content" => "", :tabindex => "-1"}
     %li#pdf_export_link
       = link_to t('pdf.export'), project_backlog_export_path(@project, format: :pdf)
+    %li#trello_export_link
+      = link_to t('trello.export'), '#'
 %section.backlog.row{ data: { project_id: @project.id } }
   .user-stories-preloader.small-12.medium-5.columns
     = image_tag 'preloader.gif'


### PR DESCRIPTION
## Make 'export to trello' link work in backlog
#### Trello board reference:
- [Trello Card #225](https://trello.com/c/wPypauYt/225-225-bug-export-to-trello-link-in-backlog-doesn-t-work)

---
#### Description:
- The logic wasn't linked to the actual link in the backlog.

---
#### Reviewers:
- @patrickschulze 

---
#### Notes:
- This card came up talking to the PO yesterday. Very quick fix. 

---
#### Risk:
- Low

---
