### PR TITLE
Corrected order for ACs and constraints in backlog section.

### DIFF
--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -11,8 +11,10 @@ class UserStory < ActiveRecord::Base
   after_create :update_next_story_number
 
   has_and_belongs_to_many :tags
-  has_many :acceptance_criterions, dependent: :destroy
-  has_many :constraints, dependent: :destroy
+  has_many :acceptance_criterions,
+    -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :constraints,
+    -> { order(created_at: :asc) }, dependent: :destroy
   belongs_to :hypothesis
   belongs_to :project
 

--- a/spec/features/project/acceptance_criteria/create_acceptance_criterion_spec.rb
+++ b/spec/features/project/acceptance_criteria/create_acceptance_criterion_spec.rb
@@ -48,4 +48,17 @@ feature 'Create a new acceptance criterion' do
     find('input#save-acceptance-criterion', visible: false).trigger('click')
     expect(page).to have_content("Description can't be blank")
   end
+
+  scenario 'should show acceptance criterions in correct order', js: true do
+    acs = create_list :acceptance_criterion, 2, user_story: user_story
+
+    visit current_path
+    find('.user-story').click
+    expect{ find('form#new_acceptance_criterion') }.not_to become_eq nil
+    expect(
+      acs.first.description
+    ).to appear_before(
+      acs.second.description
+    )
+  end
 end

--- a/spec/features/project/constraints/create_constraint_spec.rb
+++ b/spec/features/project/constraints/create_constraint_spec.rb
@@ -46,4 +46,17 @@ feature 'Create a new constraint' do
     find('input#save-constraint', visible: false).trigger('click')
     expect(page).to have_content("Description can't be blank")
   end
+
+  scenario 'should show constraints in correct order', js: true do
+    constraints = create_list :constraint, 2, user_story: user_story
+
+    visit current_path
+    find('.user-story').click
+    expect{ find('form#new_constraint') }.not_to become_eq nil
+    expect(
+      constraints.first.description
+    ).to appear_before(
+      constraints.second.description
+    )
+  end
 end

--- a/spec/support/matchers/appear_before_matcher.rb
+++ b/spec/support/matchers/appear_before_matcher.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :appear_before do |later_content|
+  match do |earlier_content|
+    page.body.index(earlier_content) < page.body.index(later_content)
+  end
+end


### PR DESCRIPTION
## Corrected order for ACs and constraints in backlog section.
#### Trello board reference:
- [Trello Card #176](https://trello.com/c/KfvhzmQk/176-constraints-are-in-reverse-order-on-the-backlog-section)

---
#### Description:
- This PR addresses the issue that when you selected a user story in the backlog section, all constraints were in reverse order.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
