### PR TITLE
Constraints and Accpetance Criterions are deletable now.

### DIFF
--- a/.reek
+++ b/.reek
@@ -67,7 +67,10 @@ PrimaDonnaMethod:
   exclude: []
 RepeatedConditional:
   enabled: true
-  exclude: []
+  exclude: [
+    'AcceptanceCriterionsController',
+    'ConstraintsController'
+  ]
   max_ifs: 2
 TooManyInstanceVariables:
   enabled: true

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -132,6 +132,8 @@ function UserStories() {
       bindTagCheckboxes();
       bindNewTag();
       refreshStories();
+      bindAcceptanceCriterionFadeOut();
+      bindConstraintFadeOut();
     });
   }
 
@@ -341,6 +343,18 @@ function UserStories() {
       $editForm.submit();
     });
   }
+
+  function bindConstraintFadeOut() {
+    $('a#delete_constraint').bind('ajax:success', function() {
+      $(this).parents('.delete-constraint-edit').fadeOut();
+    });
+  }
+
+  function bindAcceptanceCriterionFadeOut() {
+    $('a#delete_acceptance_criterion').bind('ajax:success', function() {
+      $(this).parents('.delete-acceptance-criterion-edit').fadeOut();
+    });
+  }
 }
 
 fullWidthForm();
@@ -487,3 +501,4 @@ function dynamicInput() {
     });
   })($);
 }
+

--- a/app/controllers/acceptance_criterions_controller.rb
+++ b/app/controllers/acceptance_criterions_controller.rb
@@ -1,34 +1,46 @@
 class AcceptanceCriterionsController < ApplicationController
-  before_action :set_user_story, only: :create
-  before_action :set_acceptance_criterion, only: :update
+  before_action :load_acceptance_criterion, only: [:update, :destroy]
+  before_action :set_user_story, only: [:create, :destroy]
 
   def create
-    @ac_service = AcceptanceCriterionServices.new(@user_story)
+    ac_service = AcceptanceCriterionServices.new(@user_story)
     response =
-      @ac_service.new_acceptance_criterion(acceptance_criterion_params)
+      ac_service.new_acceptance_criterion(acceptance_criterion_params)
     render json: response, status: (response.success ? 201 : 422)
   end
 
   def update
     @acceptance_criterion.update_attributes(acceptance_criterion_params)
-    @ac_service =
+    ac_service =
       AcceptanceCriterionServices.new(@acceptance_criterion.user_story)
     response =
-      @ac_service.update_acceptance_criterion(@acceptance_criterion)
+      ac_service.update_acceptance_criterion(@acceptance_criterion)
+    render json: response, status: (response.success ? 201 : 422)
+  end
+
+  def destroy
+    @user_story.acceptance_criterions.destroy(@acceptance_criterion)
+    acceptance_criterion_service = AcceptanceCriterionServices.new(
+      @acceptance_criterion.user_story)
+    response =
+      acceptance_criterion_service.delete_acceptance_criterion(
+        @acceptance_criterion)
     render json: response, status: (response.success ? 201 : 422)
   end
 
   private
 
   def acceptance_criterion_params
-    params.require(:acceptance_criterion).permit(:description)
+    params.require(:acceptance_criterion).permit(:description, :user_story_id)
   end
 
   def set_user_story
-    @user_story = UserStory.find(params[:user_story_id])
+    @user_story =
+      @acceptance_criterion.try(:user_story) ||
+      UserStory.find(params[:user_story_id])
   end
 
-  def set_acceptance_criterion
+  def load_acceptance_criterion
     @acceptance_criterion = AcceptanceCriterion.find(params[:id])
   end
 end

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -1,19 +1,27 @@
 class ConstraintsController < ApplicationController
-  before_action :load_constraint, only: :update
-  before_action :set_user_story, only: :create
+  before_action :load_constraint, only: [:update, :destroy]
+  before_action :set_user_story, only: [:create, :destroy]
 
   def create
-    @constraint_service = ConstraintServices.new(@user_story)
+    constraint_service = ConstraintServices.new(@user_story)
     response =
-      @constraint_service.new_constraint(constraint_params)
+      constraint_service.new_constraint(constraint_params)
     render json: response, status: (response.success ? 201 : 422)
   end
 
   def update
     @constraint.update_attributes(constraint_params)
-    @constraint_service = ConstraintServices.new(@constraint.user_story)
+    constraint_service = ConstraintServices.new(@constraint.user_story)
     response =
-      @constraint_service.update_constraint(@constraint)
+      constraint_service.update_constraint(@constraint)
+    render json: response, status: (response.success ? 201 : 422)
+  end
+
+  def destroy
+    @user_story.constraints.destroy(@constraint)
+    constraint_service = ConstraintServices.new(@constraint.user_story)
+    response =
+      constraint_service.delete_constraint(@constraint)
     render json: response, status: (response.success ? 201 : 422)
   end
 
@@ -23,14 +31,13 @@ class ConstraintsController < ApplicationController
     params.require(:constraint).permit(:description, :user_story_id)
   end
 
-  def load_constraint
-    @constraint = Constraint.includes([:user_story]).find(params[:id])
-  end
-
   def set_user_story
     @user_story =
       @constraint.try(:user_story) ||
-      UserStory
-      .find(params[:user_story_id])
+      UserStory.find(params[:user_story_id])
+  end
+
+  def load_constraint
+    @constraint = Constraint.includes([:user_story]).find(params[:id])
   end
 end

--- a/app/services/acceptance_criterion_services.rb
+++ b/app/services/acceptance_criterion_services.rb
@@ -29,6 +29,17 @@ class AcceptanceCriterionServices
     @common_response
   end
 
+  def delete_acceptance_criterion(acceptance_criterion)
+    if acceptance_criterion.delete
+      @common_response.data[:edit_url] =
+      @route_helper.edit_user_story_path(@user_story)
+    else
+      @common_response.success = false
+      @common_response.errors += acceptance_criterion.errors.full_messages
+    end
+    @common_response
+  end
+
   private
 
   def assign_common_response(acceptance_criterion)

--- a/app/services/constraint_services.rb
+++ b/app/services/constraint_services.rb
@@ -29,6 +29,17 @@ class ConstraintServices
     @common_response
   end
 
+  def delete_constraint(constraint)
+    if constraint.delete
+      @common_response.data[:edit_url] =
+        @route_helper.edit_user_story_path(@user_story)
+    else
+      @common_response.success = false
+      @common_response.errors += constraint.errors.full_messages
+    end
+    @common_response
+  end
+
   private
 
   def assign_common_response(constraint)

--- a/app/views/acceptance_criterions/_edit.haml
+++ b/app/views/acceptance_criterions/_edit.haml
@@ -1,1 +1,3 @@
-= render 'acceptance_criterions/form', criterion: acceptance_criterion
+.delete-acceptance-criterion-edit
+  = render 'acceptance_criterions/form', criterion: acceptance_criterion
+  = link_to 'Delete', acceptance_criterion_path(acceptance_criterion), class: 'delete-acceptance-criterion', method: :delete, remote: true, id: 'delete_acceptance_criterion'

--- a/app/views/constraints/_edit.haml
+++ b/app/views/constraints/_edit.haml
@@ -1,1 +1,3 @@
-= render 'constraints/form', constraint: constraint
+.delete-constraint-edit
+  = render 'constraints/form', constraint: constraint
+  = link_to 'Delete', constraint_path(constraint), class: 'delete-constraint', method: :delete, remote: true, id: 'delete_constraint'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,13 +47,16 @@ Railsroot::Application.routes.draw do
     get '/backlog', controller: :projects, action: :backlog
     resources :attachments, only: [:index, :create]
 
-    post '/copy', contoller: :projects, action: :copy
+    post '/copy', controller: :projects, action: :copy
   end
 
   resources :hypotheses, only: [:destroy] do
     resources :goals, only: [:create]
     get '/user_stories', controller: :hypotheses, action: :list_stories
   end
+
+  resources :constraints, only: :destroy
+  resources :acceptance_criterions, only: :destroy
 
   post 'user_stories/copy', controller: :user_stories, action: :copy
   resources :goals, only: [:edit, :update, :destroy]

--- a/spec/controllers/acceptance_criterions_controller_spec.rb
+++ b/spec/controllers/acceptance_criterions_controller_spec.rb
@@ -46,4 +46,20 @@ RSpec.describe AcceptanceCriterionsController do
       expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
     end
   end
+
+  describe 'DELETE destroy' do
+    let!(:acceptance_criterion) { create :acceptance_criterion, user_story: user_story }
+
+    it 'sends a success response with the edit url' do
+      request.env['HTTP_REFERER'] = project_user_stories_path(project.id)
+      delete :destroy, id: acceptance_criterion.id
+
+      expect(AcceptanceCriterion.exists? acceptance_criterion.id).to be_falsy
+      user_story = acceptance_criterion.user_story
+      hash_response = JSON.parse(response.body)
+
+      expect(hash_response['success']).to eq(true)
+      expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
+    end
+  end
 end

--- a/spec/controllers/constraints_controller_spec.rb
+++ b/spec/controllers/constraints_controller_spec.rb
@@ -46,4 +46,20 @@ RSpec.describe ConstraintsController do
       expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
     end
   end
+
+  describe 'DELETE destroy' do
+    let!(:constraint) { create :constraint, user_story: user_story }
+
+    it 'sends a success response with the edit url' do
+      request.env['HTTP_REFERER'] = project_user_stories_path(project.id)
+      delete :destroy, id: constraint.id
+
+      expect(Constraint.exists? constraint.id).to be_falsy
+      user_story = constraint.user_story
+      hash_response = JSON.parse(response.body)
+
+      expect(hash_response['success']).to eq(true)
+      expect(hash_response['data']['edit_url']).to eq(edit_user_story_path(user_story))
+    end
+  end
 end

--- a/spec/features/project/acceptance_criteria/delete_acceptance_criterion_spec.rb
+++ b/spec/features/project/acceptance_criteria/delete_acceptance_criterion_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+feature 'Delete an acceptance criterion' do
+  let!(:user)                 { create :user }
+  let!(:project)              { create :project, owner: user }
+  let!(:user_story)           { create :user_story, project: project }
+  let!(:acceptance_criterion) {
+    create :acceptance_criterion,
+    user_story: user_story
+  }
+
+  background do
+    sign_in user
+    visit project_user_stories_path project
+    find('.user-story').click
+  end
+
+  scenario 'should show me a delete link', js: true do
+    within '.delete-acceptance-criterion-edit' do
+      expect(page).to have_selector 'a#delete_acceptance_criterion'
+    end
+  end
+
+  scenario 'should delete an acceptance_criterion successfully', js: true do
+    within '.delete-acceptance-criterion-edit' do
+      find('a#delete_acceptance_criterion').trigger('click')
+    end
+
+    expect{ AcceptanceCriterion.exists? acceptance_criterion.id }.to become_eq false
+  end
+
+  scenario 'should remove the acceptance_criterion from the form', js: true do
+    within '.delete-acceptance-criterion-edit' do
+      find('a#delete_acceptance_criterion').trigger('click')
+    end
+
+    expect(page).not_to have_selector('.delete-acceptance-criterion-edit')
+  end
+end

--- a/spec/features/project/constraints/delete_constraint_spec.rb
+++ b/spec/features/project/constraints/delete_constraint_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+feature 'Delete a constraint' do
+  let!(:user)       { create :user }
+  let!(:project)    { create :project, owner: user }
+  let!(:user_story) { create :user_story, project: project }
+  let!(:constraint) { create :constraint, user_story: user_story }
+
+  background do
+    sign_in user
+    visit project_user_stories_path project
+    find('.user-story').click
+  end
+
+  scenario 'should show me a delete link', js: true do
+    within '.delete-constraint-edit' do
+      expect(page).to have_selector 'a#delete_constraint'
+    end
+  end
+
+  scenario 'should delete a constraint successfully', js: true do
+    within '.delete-constraint-edit' do
+      find('a#delete_constraint').trigger('click')
+    end
+
+    expect{ Constraint.exists? constraint.id }.to become_eq false
+  end
+
+  scenario 'should remove the constraint from the form', js: true do
+    within '.delete-constraint-edit' do
+      find('a#delete_constraint').trigger('click')
+    end
+
+    expect(page).not_to have_selector('.delete-constraint-edit')
+  end
+end

--- a/spec/services/acceptance_criterion_services_spec.rb
+++ b/spec/services/acceptance_criterion_services_spec.rb
@@ -37,3 +37,19 @@ feature 'update acceptance criterion' do
     expect(response.data[:edit_url]).to eq(edit_user_story_path(user_story))
   end
 end
+
+feature 'delete acceptance criterion' do
+  let(:user_story)           { create :user_story }
+  let(:criterion_service)    { AcceptanceCriterionServices.new(user_story) }
+  let(:acceptance_criterion) {
+    create :acceptance_criterion,
+    user_story: user_story
+  }
+
+  scenario 'should load the response with user story edit url' do
+    response = criterion_service.delete_acceptance_criterion(acceptance_criterion)
+
+    expect(response.success).to eq(true)
+    expect(response.data[:edit_url]).to eq(edit_user_story_path(user_story))
+  end
+end

--- a/spec/services/constraint_services_spec.rb
+++ b/spec/services/constraint_services_spec.rb
@@ -36,3 +36,18 @@ feature 'update constraint' do
     expect(response.data[:edit_url]).to eq(edit_user_story_path(user_story))
   end
 end
+
+feature 'delete constraint' do
+  let(:user_story)         { create :user_story }
+  let(:constraint_service) { ConstraintServices.new(user_story) }
+  let(:constraint) {
+    create :constraint,
+    user_story: user_story
+  }
+
+  scenario 'should load the response with user story edit url' do
+    response = constraint_service.delete_constraint(constraint)
+    expect(response.success).to eq(true)
+    expect(response.data[:edit_url]).to eq(edit_user_story_path(user_story))
+  end
+end


### PR DESCRIPTION
## Deletable Constraints and Acceptance Criterions
#### Trello board reference:
- [Trello Card #232](https://trello.com/c/s5Mct9TU/232-as-a-user-i-should-be-able-to-delete-an-acceptance-criteria-and-a-constraint-so-that-i-can-remove-it)

---
#### Description:
- This PR makes constraints and ACs deletable via ajax. When you delete an AC or constraint the edit form for them will be faded out so that the user isn't able to interact with them anymore.

---
#### Reviewers:
- @vicocas

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- 

---
#### Preview:
- N/A
