### PR TITLE
Add js feature to make Backlog's AC and Constraints inputs resizable

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require i18n/translations
 //= require init
 //= require projects/projects.js.erb
+//= require assets/customTextArea
 //= require canvases/canvases
 //= require hypotheses/hypotheses
 //= require hypotheses/userStory

--- a/app/assets/javascripts/assets/customTextArea.js
+++ b/app/assets/javascripts/assets/customTextArea.js
@@ -1,0 +1,21 @@
+function CustomTextArea() {
+  var resizeTextarea = function(el) {
+    var offset = el.offsetHeight - el.clientHeight;
+    $(el).css('height', 'auto').css('height', el.scrollHeight + offset);
+  };
+
+  $('.resizable-text-area').each(function() {
+    $(this).height( 0 );
+    $(this).height( this.scrollHeight );
+
+    $(this).on('keyup input', function() { resizeTextarea(this); });
+  });
+
+  $('.resizable-text-area').bind('keypress', function(e) {
+    if(e.keyCode === 13 ) {
+      $(this.form).submit();
+      resizeTextarea(this);
+      return false;
+    }
+  })
+}

--- a/app/assets/javascripts/canvases/canvases.js
+++ b/app/assets/javascripts/canvases/canvases.js
@@ -5,17 +5,6 @@ function Canvases() {
       $currentQuestion   = $('#current-question'),
       currentQuestionVal = $currentQuestion.val();
 
-  $canvasTextarea.each(function(array) {
-    $(this).height($('textarea')[array].scrollHeight - 16);
-
-    var offset = this.offsetHeight - this.clientHeight;
-    var resizeTextarea = function(el) {
-        $(el).css('height', 'auto').css('height', el.scrollHeight + offset);
-    };
-
-    $(this).on('keyup input', function() { resizeTextarea(this); });
-  });
-
   $canvasFields.not(':eq(0)').hide();
   $canvasFields.css('opacity', 1);
 

--- a/app/assets/javascripts/canvases/form.js
+++ b/app/assets/javascripts/canvases/form.js
@@ -1,3 +1,4 @@
 $(document).ready(function() {
+  new CustomTextArea();
   new Canvases();
 });

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -267,6 +267,8 @@
       padding-top: rem-calc(20);
     }
 
+    .edit-backlog-inputs { padding-left: rem-calc(15); }
+
     .constraint-input,
     .backlog-placeholder {
       padding-left: 0;
@@ -275,13 +277,27 @@
 
     .acceptance-criterion-form,
     .constraint-form {
-      margin-bottom: rem-calc(20);
+      margin-bottom: rem-calc(5);
+
+      form { position: relative; }
 
       input {
         color: $secondary-color;
         font-size: rem-calc(14);
         padding-left: 0;
         @include input-placeholder { font-style: italic; };
+      }
+
+      textarea {
+        background-color: $white;
+        border: 0;
+        color: $black-90;
+        display: inline-block;
+        font-size: rem-calc(14);
+        line-height: 1.4;
+        margin-bottom: 0;
+        padding: 0;
+        resize: none;
       }
 
       .edit-constraint input {
@@ -293,8 +309,10 @@
         color: $lab-color;
         content: '\2022';
         font-size: rem-calc(30);
+        left: rem-calc(-15);
         margin-right: rem-calc(5);
-        vertical-align: middle;
+        position: absolute;
+        top: rem-calc(-2);
       }
     } // acceptance criteria
 
@@ -314,12 +332,15 @@
 } // backlog
 
 .backlog-placeholder {
-  color: $black-40;
-  font-size: rem-calc(16);
   margin-bottom: rem-calc(20);
   padding-left: 0;
 
-  @include input-placeholder { font-style: italic; };
+  @include input-placeholder {
+    color: $black-40;
+    font-size: rem-calc(15);
+    font-style: italic;
+    padding: rem-calc(5 0);
+  };
 } // backlog placeholders
 
 .user-story-component-error { display: none; }

--- a/app/assets/stylesheets/_canvas.scss
+++ b/app/assets/stylesheets/_canvas.scss
@@ -49,6 +49,8 @@
     } // canvas ul
   } // left wrapper
 
+  .segment-field { @include input-placeholder { font-style: italic; }; }
+
   .right-content-wrapper {
     padding-left: rem-calc(40);
 
@@ -68,6 +70,8 @@
     textarea {
       @include transition(box-shadow .25s, ease-in, height .15s, ease-in);
       @include border-radius($global-radius);
+      background-color: $white;
+      border-color: $white;
       font-size: rem-calc(14);
       max-height: rem-calc(520);
       min-height: rem-calc(50);

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -17,6 +17,8 @@
 input,
 select { outline: 0; }
 
+.resizable-text-area { min-height: rem-calc(1.7); }
+
 .arbor-logo {
   margin: rem-calc(60) auto rem-calc(45);
   width: rem-calc(130);

--- a/app/views/acceptance_criterions/_edit.haml
+++ b/app/views/acceptance_criterions/_edit.haml
@@ -1,3 +1,3 @@
-.delete-acceptance-criterion-edit
+.delete-acceptance-criterion-edit.edit-backlog-inputs
   = render 'acceptance_criterions/form', criterion: acceptance_criterion
   = link_to 'Delete', acceptance_criterion_path(acceptance_criterion), class: 'delete-acceptance-criterion', method: :delete, remote: true, id: 'delete_acceptance_criterion'

--- a/app/views/acceptance_criterions/_form.haml
+++ b/app/views/acceptance_criterions/_form.haml
@@ -1,5 +1,7 @@
 = form_for criterion do |form|
   - unless criterion.kind_of?(Array)
     %span.bullet
-  = form.text_field :description, class: 'backlog-placeholder', placeholder: t('backlog.user_stories.enter_criterion')
+  = form.text_area :description, class: 'backlog-placeholder resizable-text-area', placeholder: t('backlog.user_stories.enter_criterion')
   = form.submit t('save'), id: 'save-acceptance-criterion', class: 'hide'
+:javascript
+  new CustomTextArea();

--- a/app/views/canvases/_canvas_form.haml
+++ b/app/views/canvases/_canvas_form.haml
@@ -3,31 +3,31 @@
   = hidden_field_tag 'current-question', current_question
   .problems-field.canvas-fields
     = label_tag :problems, t('problems_title')
-    = text_area_tag :problems, canvas.problems, data: { question: 'problems' }
+    = text_area_tag :problems, canvas.problems, data: { question: 'problems' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .solutions-field.canvas-fields
     = label_tag :solutions, t('solutions_title')
-    = text_area_tag :solutions, canvas.solutions, data: { question: 'solutions' }
+    = text_area_tag :solutions, canvas.solutions, data: { question: 'solutions' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .alternative-field.canvas-fields
     = label_tag :alternative, t('alternative_title')
-    = text_area_tag :alternative, canvas.alternative, data: { question: 'alternative' }
+    = text_area_tag :alternative, canvas.alternative, data: { question: 'alternative' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .advantage-field.canvas-fields
     = label_tag :advantage, t('advantage_title')
-    = text_area_tag :advantage, canvas.advantage, data: { question: 'advantage' }
+    = text_area_tag :advantage, canvas.advantage, data: { question: 'advantage' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .segment-field.canvas-fields
     = label_tag :segment, t('segment_title')
-    = text_area_tag :segment, canvas.segment, data: { question: 'segment' }
+    = text_area_tag :segment, canvas.segment, data: { question: 'segment' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .channel-field.canvas-fields
     = label_tag :channel, t('channel_title')
-    = text_area_tag :channel, canvas.channel, data: { question: 'channel' }
+    = text_area_tag :channel, canvas.channel, data: { question: 'channel' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .value-proposition-field.canvas-fields
     = label_tag :value_proposition, t('value_proposition_title')
-    = text_area_tag :value_proposition, canvas.value_proposition, data: { question: 'value-proposition' }
+    = text_area_tag :value_proposition, canvas.value_proposition, data: { question: 'value-proposition' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .revenue-streams-field.canvas-fields
     = label_tag :revenue_streams, t('revenue_streams_title')
-    = text_area_tag :revenue_streams, canvas.revenue_streams, data: { question: 'revenue-streams' }
+    = text_area_tag :revenue_streams, canvas.revenue_streams, data: { question: 'revenue-streams' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   .cost-structure-field.canvas-fields
     = label_tag :cost_structure, t('cost_structure_title')
-    = text_area_tag :cost_structure, canvas.cost_structure, data: { question: 'cost-structure' }
+    = text_area_tag :cost_structure, canvas.cost_structure, data: { question: 'cost-structure' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
   = submit_tag :save, class: 'button radius small secondary-btn', id: 'save-canvas'
 - content_for :custom_js do
   = javascript_include_tag 'canvases/form'

--- a/app/views/constraints/_edit.haml
+++ b/app/views/constraints/_edit.haml
@@ -1,3 +1,3 @@
-.delete-constraint-edit
+.delete-constraint-edit.edit-backlog-inputs
   = render 'constraints/form', constraint: constraint
   = link_to 'Delete', constraint_path(constraint), class: 'delete-constraint', method: :delete, remote: true, id: 'delete_constraint'

--- a/app/views/constraints/_form.haml
+++ b/app/views/constraints/_form.haml
@@ -1,5 +1,7 @@
 = form_for constraint do |form|
   - unless constraint.kind_of?(Array)
     %span.bullet
-  = form.text_field :description, class: 'constraint-input backlog-placeholder', placeholder: t('backlog.user_stories.enter_constraint')
+  = form.text_area :description, class: 'constraint-input backlog-placeholder resizable-text-area', maxlength: 254, placeholder: t('backlog.user_stories.enter_constraint')
   = form.submit t('save'), id: 'save-constraint', class: 'hide'
+:javascript
+  new CustomTextArea();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,8 @@ en:
     acceptance_criterions: "Acceptance Criteria"
     constraints: "Constraints"
     tags: 'Tags'
+  canvas:
+    textarea_placeholder: "Click here to enter text"
   attachment:
     link:
       enter_url: "Paste link here"

--- a/spec/features/project/copy_project_spec.rb
+++ b/spec/features/project/copy_project_spec.rb
@@ -151,7 +151,7 @@ feature 'Copy project', js: true do
     end
 
     within 'form.edit_constraint' do
-      expect(find('input.constraint-input').value).to have_text(constraint.description)
+      expect(find('textarea.constraint-input').value).to have_text(constraint.description)
     end
   end
 
@@ -174,7 +174,7 @@ feature 'Copy project', js: true do
     end
 
     within 'form.edit_acceptance_criterion' do
-      expect(find('input#acceptance_criterion_description').value).to have_text(criterion.description)
+      expect(find('textarea#acceptance_criterion_description').value).to have_text(criterion.description)
     end
   end
 end


### PR DESCRIPTION
## Add JS feature to make Backlog's AC & Constraints inputs resizable
#### Trello board reference:
- [Trello Card #216](https://trello.com/c/Tk0c2RAH/216-216-when-you-select-a-user-story-in-the-backlog-section-then-you-cannot-see-the-full-acs-and-constraints)

---
#### Description:
- Corrects way that inputs were showed on Backlog's Acceptance Critera and Constraints.

---
#### Reviewers:
- @damian

---
#### Notes:
- 

---
#### Tasks:
- [x] Make inputs as textareas
- [x] Add js to make them resizable
- [x] Add same feature to canvas inputs

---
#### Risk:
- Medium

---
#### Preview:

http://cl.ly/image/0T1Y2P3B072f
