### PR TITLE
Add press enter hint to canvas section.

### DIFF
--- a/app/assets/stylesheets/_canvas.scss
+++ b/app/assets/stylesheets/_canvas.scss
@@ -80,7 +80,18 @@
       &:focus {
         @include box-shadow(0 0 5px 0 $success-color);
         border-color: $success-color;
+
+        + .enter { display: block; }
       }
+    }
+
+    .enter {
+      color: $font-color-3;
+      display: none;
+      font-size: rem-calc(10);
+      font-weight: $font-weight-normal;
+      margin-bottom: rem-calc(15);
+      text-align: right;
     }
   } // right content
 } // canvas

--- a/app/views/canvases/_canvas_form.haml
+++ b/app/views/canvases/_canvas_form.haml
@@ -4,30 +4,39 @@
   .problems-field.canvas-fields
     = label_tag :problems, t('problems_title')
     = text_area_tag :problems, canvas.problems, data: { question: 'problems' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .solutions-field.canvas-fields
     = label_tag :solutions, t('solutions_title')
     = text_area_tag :solutions, canvas.solutions, data: { question: 'solutions' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .alternative-field.canvas-fields
     = label_tag :alternative, t('alternative_title')
     = text_area_tag :alternative, canvas.alternative, data: { question: 'alternative' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .advantage-field.canvas-fields
     = label_tag :advantage, t('advantage_title')
     = text_area_tag :advantage, canvas.advantage, data: { question: 'advantage' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .segment-field.canvas-fields
     = label_tag :segment, t('segment_title')
     = text_area_tag :segment, canvas.segment, data: { question: 'segment' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .channel-field.canvas-fields
     = label_tag :channel, t('channel_title')
     = text_area_tag :channel, canvas.channel, data: { question: 'channel' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .value-proposition-field.canvas-fields
     = label_tag :value_proposition, t('value_proposition_title')
     = text_area_tag :value_proposition, canvas.value_proposition, data: { question: 'value-proposition' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .revenue-streams-field.canvas-fields
     = label_tag :revenue_streams, t('revenue_streams_title')
     = text_area_tag :revenue_streams, canvas.revenue_streams, data: { question: 'revenue-streams' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   .cost-structure-field.canvas-fields
     = label_tag :cost_structure, t('cost_structure_title')
     = text_area_tag :cost_structure, canvas.cost_structure, data: { question: 'cost-structure' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
+    %p.enter press &#8629; to finish
   = submit_tag :save, class: 'button radius small secondary-btn', id: 'save-canvas'
 - content_for :custom_js do
   = javascript_include_tag 'canvases/form'


### PR DESCRIPTION
## Feedback Canvas: add 'press enter to save' hint. Similar to lab section.
#### Trello board reference:
- [Trello Card #245](https://trello.com/c/m5JpdXkh/245-245-feedback-canvas-add-press-enter-to-save-hint-similar-to-lab-section)

---
#### Description:
- Add the hint <<press ↵ to finish >> on canvas section when user is focused on the text area

---
#### Reviewers:
- @rosinanabazas

---
#### Notes:
- 

---
#### Tasks:
- [x] Add a hidden p with the message
- [x] Make a css rule that when text area is focused on canvas right content it reveal the message

---
#### Risk:
- Low

---
#### Preview:

<img width="529" alt="screen shot 2015-11-02 at 16 05 05" src="https://cloud.githubusercontent.com/assets/6106206/10891243/88d6b41c-817b-11e5-9101-02cdff5e2c71.png">
<img width="517" alt="screen shot 2015-11-02 at 16 05 11" src="https://cloud.githubusercontent.com/assets/6106206/10891247/8dcaa49c-817b-11e5-8928-f55ae4c32885.png">
