### PR TITLE
Added js function to resize inputs

### DIFF
--- a/app/assets/javascripts/hypotheses/userStory.js
+++ b/app/assets/javascripts/hypotheses/userStory.js
@@ -87,6 +87,11 @@ function UserStory() {
 
         bindUserStoriesSortEvent();
 
+        //iterate over actions and set the size of the containers to fit their content
+        var elementsThatNeedWidthFixes = ['.action#user_story_action', '.result#user_story_result'];
+        fixInputWidths(elementsThatNeedWidthFixes);
+
+
         var $userStoryForm = $('#edit_user_story_' + userStoryId);
         $appContent.scrollTo($userStoryForm, 200);
     });
@@ -128,4 +133,27 @@ function UserStory() {
 
     return false;
   });
+}
+
+// this function receives an array of class#id of elements that need to be width-fixed, Ale
+function fixInputWidths(elementsClassIds) {
+  for (var i in elementsClassIds) {
+    $(elementsClassIds[i]).each(function(i, obj) {
+      var width = stringWidthInPixels(obj.value, this.id);
+      obj.style.minWidth = width + 'px';
+    });
+  }
+}
+// width calculator considering font used, and adding 3 px in case italic, Ale
+function stringWidthInPixels(string, elementId) {
+  // using an auxiliary canvas I can measure the text
+  var actualFont = window.getComputedStyle(document.getElementById(elementId)).font;
+  var canvas = document.createElement('canvas');
+  var ctx = canvas.getContext('2d');
+  ctx.font = actualFont;
+  //just in case we add it 3 pxs.
+  var width = ctx.measureText(string).width + 3;
+
+  canvas = null;
+  return width;
 }


### PR DESCRIPTION
## Bug Certain texts crops when too long
#### Trello board reference:
- [Trello Card #130](https://trello.com/c/RC7wkYIq)

---
#### Description:
- It happened on enter (submit form) because of the server call.

---
#### Reviewers:
- @bocha @damian

---
#### Notes:
- When the user hits enter and the page has to go to the server for rendering, then it loads the commons styles for the input text boxes. By default they were seated on 20 px width; so I have added a call to a custom function on the submit event, that reads the input content and considering the font calculate the min-width, and with that style property it adjusts the size.

---
#### Tasks:
- [x] Created all js functions necessary to iterate over elements that needed, and added min-width to their styles.

---
#### Risk:
- Medium

---
#### Preview:
- N/A
