### PR TITLE
Add styles for Total Story points

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -22,11 +22,13 @@
     ul {
       font-size: rem-calc(14);
       overflow: hidden;
+
+      &:last-child { border-bottom: 1px solid $black-10; }
     }
 
     .user-story {
       @include transition(background-color .25s ease-in);
-      border-bottom: 1px solid $black-10;
+      border-top: 1px solid $black-10;
       cursor: pointer;
       padding: rem-calc(20 45 20 15);
       position: relative;
@@ -472,3 +474,23 @@
 
   &:hover { @include opacity(.9); }
 }
+
+// --------------------------------------------------------
+//  TOTAL STORY POINTS
+// --------------------------------------------------------
+
+.total-points {
+  color: $lab-color;
+  font-size: rem-calc(14);
+  font-weight: $font-weight-bold;
+  padding: rem-calc(10 0 10 15);
+  text-transform: uppercase;
+
+  p {
+    color: $black;
+    display: inline-block;
+    font-size: rem-calc(13);
+    font-weight: $font-weight-bold;
+    margin-bottom: 0;
+  }
+} // total points

--- a/app/views/user_stories/_backlog_list.haml
+++ b/app/views/user_stories/_backlog_list.haml
@@ -2,8 +2,9 @@
   %input{ type: 'text', placeholder: t('backlog.filter'), id: 'stories-filter', data: { project_id: project.id } }
 .story-tags.applied-filters{ id: 'tag-list'}
   = render 'tags/list'
-= total_points
-= t('backlog.total_points')
+.total-points
+  = total_points
+  %p= t('backlog.total_points')
 .user-stories
   - user_stories.each do |user_story|
     %ul.user-story-list{ data: { url: project_reorder_backlog_path(project) } }


### PR DESCRIPTION
## Style Total Story Points on backlog
#### Trello board reference:
- [Trello Card #236](https://trello.com/c/vrPso5kL/236-236-3-as-a-user-i-should-be-able-to-see-a-total-count-of-story-points-of-my-backlog-so-that-i-can-easily-see-how-large-my-backlo)

---
#### Description:
- 

---
#### Reviewers:
- @damian

---
#### Notes:
- 

---
#### Tasks:
- [x] Add new class to separate story numbers and text
- [x] Style story number
- [x] Style p text
- [x] Change user storie's border-bottom to border-top to delimit user story and total points

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-11-03 at 5 23 35 p m](https://cloud.githubusercontent.com/assets/6147409/10920592/aebcfaa4-824f-11e5-957c-8c2287f6a1c1.png)
