### PR TITLE
- Update user story first label.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
       enter_role: "<type of user>"
       enter_action: "<some function>"
       enter_result: "<some benefit>"
-      role: "As a"
+      role: "As a/an"
       action_prefix: "I"
       action_suffix: "be able to"
       action: "I %{priority} be able to"

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe UserStory do
     let(:entity) do
       build :user_story, role: 'User', action: 'work', result: 'test'
     end
-    let(:description) { 'As a User I should be able to work so that test' }
+    let(:description) { 'As a/an User I should be able to work so that test' }
   end
 
   describe 'story_number' do


### PR DESCRIPTION
#### Trello board reference:
- [Trello Card #240](https://trello.com/c/XR5Q5ENf/240-240-have-a-an-instead-of-just-a-in-the-new-user-story-form-in-case-you-want-to-add-as-an-admin)

---
#### Description:
- We need to have 'a/an' instead of just 'a' in the new user story form. In case you want to add: 'As an admin...'

---
#### Reviewers:
- @rosinanabazas, @doshii

---
#### Notes:
- 

---
#### Tasks:
- [x] Update user story first label.

---
#### Risk:
- Low

---
#### Preview:

![image](https://trello-attachments.s3.amazonaws.com/5633909ca0bdb9d48e8e665c/1328x322/03808718eb4dd20a65f898035634ded5/Screenshot_2015-11-04_11.45.09.png)
