### PR TITLE
Fix sidebar white space when filter is open.

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -462,6 +462,8 @@
   .ui-menu-item:hover { color: $black-90; }
 }
 
+.ui-helper-hidden-accessible { display: none; }
+
 .applied-filters {
   display: none;
   margin-right: rem-calc(15);
@@ -492,9 +494,12 @@
     background-color: $black-30;
     color: $white;
     content: 'x';
+    display: inline-block;
     font-size: rem-calc(8);
+    height: rem-calc(14);
+    margin-right: rem-calc(3);
     padding: rem-calc(2 4);
-    vertical-align: middle;
+    vertical-align: top;
   }
 
   &:hover { @include opacity(.9); }


### PR DESCRIPTION
#### Trello board reference:
- [Trello Card #223](https://trello.com/c/MeY6zKjL/223-223-bug-white-space-in-sidebar-when-scrolling-down-with-the-filter-dropdown-open)
- [Trello Card #252](https://trello.com/c/Zx0gYm0o/252-252-the-close-icon-in-the-selected-tag-label-should-be-properly-centered)

---
#### Description:
- White space in sidebar when scrolling down with the filter dropdown open.
- The close icon in the selected tag label should be properly centered.

---
#### Reviewers:
- @rosinanabazas, @doshii 

---
#### Notes:
- This **[bug](https://trello.com/c/Ad0gN6NZ)** was noticed when fixing this. Still remain unaddressed.

---
#### Tasks:
- [x] Fix opened filter layout bug.
- [x] Adjust close filter icon styles.

---
#### Risk:
- Low

---
#### Preview:
- N/A
