### PR TITLE
Fix internationalization, move minimum-password lenght styles

### DIFF
--- a/app/assets/stylesheets/_signin.scss
+++ b/app/assets/stylesheets/_signin.scss
@@ -8,12 +8,6 @@
     vertical-align: middle;
   }
 
-  .password-information {
-    color: $black-30;
-    font-size: rem-calc(13);
-    padding-bottom: rem-calc(10);
-  }
-
   .forgot-password {
     color: $black-40;
     display: block;
@@ -26,3 +20,9 @@
 .password-length { color: $black-50; }
 
 .password-new { margin-top: rem-calc(10); }
+
+.password-information {
+  color: $black-30;
+  font-size: rem-calc(13);
+  padding-bottom: rem-calc(10);
+}

--- a/app/views/devise/passwords/edit.haml
+++ b/app/views/devise/passwords/edit.haml
@@ -2,19 +2,19 @@
   .arbor-logo
     = image_tag('arbor-logo.svg')
   .large-6.large-centered.columns.reset-form
-    %h2= t('login.recover_password.change')
+    %h2= t('recover_password.change')
     = form_for(resource, as: resource_name, url: password_path(resource_name),
     html: { method: :put }) do |f|
       = devise_error_messages!
       = f.hidden_field :reset_password_token
       .field
         - if @minimum_password_length
-          %span.password-length (#{@minimum_password_length} characters minimum)
+          %span.password-information (#{@minimum_password_length} characters minimum)
       .field.password-new
         = image_tag('icons/password-icon.svg', class: 'icon')
-        = f.password_field :password, placeholder: t('login.recover_password.password'), class: 'with-icon radius login', autocomplete: 'off', required: true
+        = f.password_field :password, placeholder: t('recover_password.password'), class: 'with-icon radius login', autocomplete: 'off', required: true
       .field
         = image_tag('icons/password-icon.svg', class: 'icon')
-        = f.password_field :password, placeholder: t('login.recover_password.confirm_password'), class: 'with-icon radius login', autocomplete: 'off', required: true
+        = f.password_field :password, placeholder: t('recover_password.confirm_password'), class: 'with-icon radius login', autocomplete: 'off', required: true
       .actions
-        = f.submit t('login.recover_password.submit'), class: 'button radius success small'
+        = f.submit t('recover_password.submit'), class: 'button radius success small'


### PR DESCRIPTION
## Fix Reset Password view
#### Trello board reference:
- [Trello Card #](https://trello.com/c/DggAO1Ii/251-reset-password-does-not-work)

---
#### Description:
- Fix Reset Password view, add general class for password information (minimum 8 chars)

---
#### Reviewers:
- @doshi

---
#### Tasks:
- [x] Fix internationalization path to fix view
- [x] Move general class for styling password information text

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-11-05 at 12 02 10 p m](https://cloud.githubusercontent.com/assets/6147409/10971840/1ba16874-83b5-11e5-9e55-59f2791d8d40.png)
