### PR TITLE
Add textarea's grey border and italic font

### DIFF
--- a/app/assets/stylesheets/_canvas.scss
+++ b/app/assets/stylesheets/_canvas.scss
@@ -64,18 +64,22 @@
 
     label {
       cursor: text;
+      font-weight: $font-weight-bold;
       margin-bottom: rem-calc(15);
     }
 
     textarea {
       @include transition(box-shadow .25s, ease-in, height .15s, ease-in);
       @include border-radius($global-radius);
-      background-color: $white;
-      border-color: $white;
+      background-color: $white;  
+      border: $white;
       font-size: rem-calc(14);
       max-height: rem-calc(520);
       min-height: rem-calc(50);
       resize: none;
+      @include input-placeholder { font-style: italic; };
+
+      &:empty { border: 1px solid $black-20; }
 
       &:focus {
         @include box-shadow(0 0 5px 0 $success-color);
@@ -83,7 +87,7 @@
 
         + .enter { display: block; }
       }
-    }
+    } // textarea
 
     .enter {
       color: $font-color-3;


### PR DESCRIPTION
## Improve Canvas' inputs styles by adding border on empty textareas
#### Trello board reference:
- [Trello Card #253](https://trello.com/c/ne2t2Zvl/253-253-fix-styles-on-canvas-placeholder-s-state)

---
#### Description:
- 

---
#### Reviewers:
- @bocha

---
#### Notes:
- 

---
#### Tasks:
- [x] Add empty pseudoclass to textarea
- [x] Add font weight bold for titles

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-11-05 at 5 26 36 p m](https://cloud.githubusercontent.com/assets/6147409/10980756/804db066-83e2-11e5-89fa-ec7fdec53c5c.png)
