### PR TITLE
Fix placeholder's line height

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -366,6 +366,7 @@
     color: $black-40;
     font-size: rem-calc(15);
     font-style: italic;
+    line-height: .8;
     padding: rem-calc(5 0);
   };
 } // backlog placeholders


### PR DESCRIPTION
## Fix placeholder and textarea's alignment
#### Trello board reference:
- [Trello Card #254](https://trello.com/c/zeiSRz5U/257-254-focus-and-placeholder-on-backlogs-ac-and-constraints-are-not-aligned)

---
#### Description:
- Placeholder's height wasn't correct so It made them look out of phase.

---
#### Reviewers:
- @doshi

---
#### Tasks:
- [x] Fix placeholder's height

---
#### Risk:
- Low
