### PR TITLE
Add export to csv that works ok on a spreadsheet import.

### DIFF
--- a/.reek
+++ b/.reek
@@ -56,6 +56,7 @@ NestedIterators:
     Hypothesis#self.to_csv,
     UserStoriesController#update,
     UserStoriesController#export,
+    SpreadsheetExporterService#self.export,
   ]
   max_allowed_nesting: 1
   ignore_iterators: []

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,7 @@
 class ProjectsController < ApplicationController
   before_action :load_project,
-                only: [:show, :edit, :update, :destroy, :log]
+                only: [:show, :edit, :update, :destroy,
+                       :log, :export_to_spreadhseet]
 
   def index
   end
@@ -88,6 +89,11 @@ class ProjectsController < ApplicationController
     project_services.replicate(current_user)
 
     redirect_to :back
+  end
+
+  def export_to_spreadhseet
+    send_data(
+      SpreadsheetExporterService.export(@project), disposition: 'inline')
   end
 
   private

--- a/app/services/spreadsheet_exporter_service.rb
+++ b/app/services/spreadsheet_exporter_service.rb
@@ -1,0 +1,31 @@
+require 'csv'
+
+class SpreadsheetExporterService
+  def self.export(project, options = { col_sep: '|' })
+    CSV.generate(options) do |csv|
+      csv << ['Points', 'Story Number', 'User Story']
+      project.hypotheses.each do |hypothesis|
+        hypothesis_row(csv, hypothesis)
+      end
+    end
+  end
+
+  def self.hypothesis_row(csv, hypothesis)
+    csv << [nil, nil, hypothesis.description]
+    hypothesis.user_stories.each do |user_story|
+      user_story_row(csv, user_story)
+      criteria_rows(csv, user_story.acceptance_criterions)
+      criteria_rows(csv, user_story.constraints)
+    end
+  end
+
+  def self.user_story_row(csv, story)
+    csv << [story.estimated_points, story.story_number, story.log_description]
+  end
+
+  def self.criteria_rows(csv, criterias)
+    criterias.each do |criteria|
+      csv << [nil, nil, "- #{criteria.description}"]
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,5 +84,7 @@ Railsroot::Application.routes.draw do
       action: :reorder_constraints,
       as: :reorder_constraints
 
+  get 'export/:id/spreadhseet', to: 'projects#export_to_spreadhseet'
+
   devise_for :users, controllers: { registrations: 'registrations' }
 end

--- a/spec/services/spreadsheet_exporter_service.rb
+++ b/spec/services/spreadsheet_exporter_service.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe SpreadsheetExporterService do
+  it 'should return a csv file separated by pipes' do
+    project = create :project
+    expect(SpreadsheetExporterService.export(project))
+      .to match("Points|Story Number|User Story")
+  end
+
+  it 'should include the hypothesis' do
+    hypothesis = create :hypothesis, description: 'My New hypothesis'
+    project = create :project, hypotheses: [hypothesis]
+    expect(SpreadsheetExporterService.export(project))
+      .to match('||My New hypothesis')
+  end
+
+  it 'should include the user stories' do
+    hypothesis = create :hypothesis, description: 'My New hypothesis'
+    user_story = create :user_story, hypothesis: hypothesis
+    project = create :project, hypotheses: [hypothesis]
+    expect(SpreadsheetExporterService.export(project))
+      .to match('2|1|As a/an User I should be able to')
+  end
+
+  it 'should include the constraints and acceptance criterions' do
+    hypothesis = create :hypothesis, description: 'My New hypothesis'
+    ac = create :acceptance_criterion, description: 'Given that I do this'
+    constraint = create :constraint, description: 'You cant do this'
+    user_story = create :user_story, hypothesis: hypothesis,
+      acceptance_criterions: [ac], constraints: [constraint]
+    project = create :project, hypotheses: [hypothesis]
+    expect(SpreadsheetExporterService.export(project))
+      .to match('||- Given that I do this')
+    expect(SpreadsheetExporterService.export(project))
+      .to match('||- You cant do this')
+  end
+end


### PR DESCRIPTION
## Add an export to csv that works for importing on google docs
#### Trello board reference:
- [Trello Card #NA]()

---
#### Description:
- Every time we need to send estimations to other teams we need to export the backlog into a google doc, this is not possible to do without some manual work, so I automated this and make a CSV document that fits into the format we use on google spreadsheets.

---
#### Reviewers:
- 

---
#### Notes:
- This doesn;t have a frontend part, it just for internal use only so only if you know the url will work.

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
