### PR TITLE
Implemented drag and drop on constraints and acceptance criteria

### DIFF
--- a/.reek
+++ b/.reek
@@ -84,7 +84,9 @@ TooManyStatements:
   enabled: true
   exclude: [
 
-    RegistrationsController#create
+    RegistrationsController#create,
+    AcceptanceCriterionServices#new_acceptance_criterion,
+    ConstraintServices#new_constraint
   ]
   max_statements: 6
 UncommunicativeMethodName:
@@ -132,5 +134,9 @@ UtilityFunction:
     ApplicationHelper#meta_description,
     ThumbnailUploader#default_link_url,
     ThumbnailUploader#default_file_url,
+    UserStory#reorder_criterions,
+    AcceptanceCriterionServices#get_order,
+    UserStory#reorder_constraints,
+    ConstraintServices#get_order
   ]
   max_helper_calls: 1

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ group :production do
 end
 
 gem 'devise'
+
+gem 'migration_data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
       mime-types (>= 1.16, < 3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
+    migration_data (0.2.0)
+      rails (>= 4.0.0.rc1)
     mime-types (2.6.2)
     mini_magick (4.3.3)
     mini_portile (0.6.2)
@@ -435,6 +437,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails
   jquery-ui-rails (= 5.0.5)
+  migration_data
   mini_magick
   mustache-js-rails
   nilify_blanks (= 1.2.1)

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -6,9 +6,11 @@ function UserStories() {
       $backlogSection       = $('section.backlog'),
       $userStoriesContainer = $('.user-stories-list-container'),
       $backlogPreloader     = $('.user-stories-preloader'),
-      projectId             = $backlogSection.data('projectId');
-      selectedTags          = [];
-      projectTags           = [];
+      projectId             = $backlogSection.data('projectId'),
+      selectedTags          = [],
+      projectTags           = [],
+      $criterionsOnList     = $('li.criterion'),
+      $criterionsList       = $('ul.criterions-list');
 
   function filterByTags(tags) {
     $('#stories-filter').autocomplete({
@@ -125,6 +127,8 @@ function UserStories() {
       $userStoryForm.html('');
       $userStoryForm.html(editForm);
       bindUserStoryEditForm();
+      bindReorderCriterionsEvents();
+      bindReorderConstraintEvents();
       bindNewAcceptanceCriterion();
       bindNewConstraint();
       bindEditAcceptanceCriterion();
@@ -160,6 +164,76 @@ function UserStories() {
         });
       }
     });
+  }
+
+
+  function bindReorderCriterionsEvents() {
+    $('li.criterion').click(function() {
+      $('li.criterion').removeClass('selected');
+      $(this).addClass('selected');
+    });
+
+    $('ul.criterions-list').sortable({
+      connectWith: '.criterions-list',
+      stop: function() {
+        var newCriterionsOrder = setCriterionsOrder(),
+            url = $('ul.criterions-list').data('url');
+            userStory = $('ul.criterions-list').data('user-story');
+        $.ajax({
+          url: url,
+          dataType: 'json',
+          method: 'PUT',
+          data: { criterions: newCriterionsOrder.criterions, user_story: userStory }
+        });
+      }
+    });
+  }
+
+  function setCriterionsOrder() {
+    var newCriterionsOrder = { criterions: [] },
+        $updatedCriterionsOnList = $('li.criterion');
+
+    $.each($updatedCriterionsOnList, function(index) {
+      var criterion = { id: $(this).data('id'), criterion_order: index + 1 };
+      newCriterionsOrder.criterions.push(criterion);
+    });
+
+    return newCriterionsOrder;
+  }
+
+  function bindReorderConstraintEvents() {
+    $('li.constraint').click(function() {
+      $('li.constraint').removeClass('selected');
+      $(this).addClass('selected');
+    });
+
+    $('ul.constraints-list').sortable({
+      connectWith: '.constraints-list',
+      stop: function() {
+        var newConstraintsOrder = setConstraintsOrder(),
+            url = $('ul.constraints-list').data('url');
+            userStory = $('ul.criterions-list').data('user-story');
+
+        $.ajax({
+          url: url,
+          dataType: 'json',
+          method: 'PUT',
+          data: { constraints: newConstraintsOrder.constraints, user_story: userStory }
+        });
+      }
+    });
+  }
+
+  function setConstraintsOrder() {
+    var newConstraintsOrder = { constraints: [] },
+        $updatedConstraintsOnList = $('li.constraint');
+
+    $.each($updatedConstraintsOnList, function(index) {
+      var constraint = { id: $(this).data('id'), constraint_order: index + 1 };
+      newConstraintsOrder.constraints.push(constraint);
+    });
+
+    return newConstraintsOrder;
   }
 
   function hideBacklog() {

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -282,7 +282,7 @@
         @include transition(color .25s ease-in, opacity .25s ease-in);
         position: absolute;
         right: 0;
-        top: rem-calc(1);
+        top: rem-calc(15);
         z-index: 99;
       }
 
@@ -300,6 +300,11 @@
     @include transition(color .25s ease-in);
     padding-left: 0;
     width: 90%;
+  }
+
+  .ui-sortable-helper {
+    padding-bottom: rem-calc(50);
+    padding-top: 0;
   }
 
   .acceptance-criterion-form,
@@ -339,7 +344,6 @@
       font-size: rem-calc(30);
       left: rem-calc(-15);
       margin-right: rem-calc(5);
-      position: absolute;
       top: rem-calc(-2);
     }
   } // acceptance criteria

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -60,6 +60,18 @@ class UserStoriesController < ApplicationController
     save_pdf(content) unless params.key?('debug')
   end
 
+  def reorder_criterions
+    @user_story = UserStory.find(params['user_story'])
+    acceptance_criterion_service = AcceptanceCriterionServices.new(@user_story)
+    render json: acceptance_criterion_service.reorder_criterions(params)
+  end
+
+  def reorder_constraints
+    @user_story = UserStory.find(params['user_story'])
+    constraints_service = ConstraintServices.new(@user_story)
+    render json: constraints_service.reorder_constraints(params)
+  end
+
   private
 
   def story_update_params

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -13,9 +13,9 @@ class UserStory < ActiveRecord::Base
 
   has_and_belongs_to_many :tags
   has_many :acceptance_criterions,
-    -> { order(created_at: :asc) }, dependent: :destroy
+    -> { order(order: :asc) }, dependent: :destroy
   has_many :constraints,
-    -> { order(created_at: :asc) }, dependent: :destroy
+    -> { order(order: :asc) }, dependent: :destroy
   belongs_to :hypothesis
   belongs_to :project
 
@@ -65,6 +65,24 @@ class UserStory < ActiveRecord::Base
   def clean_log
     activities.delete_all
     [clean_criterions_log, clean_constraints_log].each(&:join)
+  end
+
+  def reorder_criterions(criterions_hash)
+    acceptance_criterions.update_all order: nil
+    criterions_hash.values.each do |criterion|
+      acceptance_criterions
+        .find(criterion['id'].to_i)
+        .update_attributes!(order: criterion['criterion_order'].to_i)
+    end
+  end
+
+  def reorder_constraints(constraints_hash)
+    constraints.update_all order: nil
+    constraints_hash.values.each do |constraint|
+      constraints
+        .find(constraint['id'].to_i)
+        .update_attributes!(order: constraint['constraint_order'].to_i)
+    end
   end
 
   private

--- a/app/services/acceptance_criterion_services.rb
+++ b/app/services/acceptance_criterion_services.rb
@@ -8,6 +8,7 @@ class AcceptanceCriterionServices
   def new_acceptance_criterion(acceptance_criterion_params)
     acceptance_criterion = AcceptanceCriterion.new(acceptance_criterion_params)
     acceptance_criterion.user_story = @user_story
+    acceptance_criterion.order = get_order(@user_story)
 
     if acceptance_criterion.save
       assign_common_response(acceptance_criterion)
@@ -40,11 +41,26 @@ class AcceptanceCriterionServices
     @common_response
   end
 
+  def reorder_criterions(acceptance_criterion_params)
+    new_order = acceptance_criterion_params['criterions']
+    @user_story.reorder_criterions(new_order)
+    { success: true }
+  end
+
   private
 
   def assign_common_response(acceptance_criterion)
     @user_story.acceptance_criterions << acceptance_criterion
     @common_response.data[:edit_url] =
       @route_helper.edit_user_story_path(@user_story)
+  end
+
+  def get_order(user_story)
+    existent_acceptance_criterions = user_story.acceptance_criterions
+    if existent_acceptance_criterions.present?
+      existent_acceptance_criterions.maximum('order') + 1
+    else
+      1
+    end
   end
 end

--- a/app/services/constraint_services.rb
+++ b/app/services/constraint_services.rb
@@ -8,6 +8,7 @@ class ConstraintServices
   def new_constraint(constraint_params)
     constraint = Constraint.new(constraint_params)
     constraint.user_story = @user_story
+    constraint.order = get_order(@user_story)
 
     if constraint.save
       assign_common_response(constraint)
@@ -40,11 +41,26 @@ class ConstraintServices
     @common_response
   end
 
+  def reorder_constraints(constraint_params)
+    new_order = constraint_params['constraints']
+    @user_story.reorder_constraints(new_order)
+    { success: true }
+  end
+
   private
 
   def assign_common_response(constraint)
     @user_story.constraints << constraint
     @common_response.data[:edit_url] =
       @route_helper.edit_user_story_path(@user_story)
+  end
+
+  def get_order(user_story)
+    existent_constraints = user_story.constraints
+    if existent_constraints.present?
+      existent_constraints.maximum('order') + 1
+    else
+      1
+    end
   end
 end

--- a/app/views/user_stories/_form.haml
+++ b/app/views/user_stories/_form.haml
@@ -70,12 +70,18 @@
     = render 'tags/new', user_story: user_story
   .acceptance-criterion-form
     = render 'acceptance_criterions/new', user_story: user_story
-    - user_story.acceptance_criterions.each do |acceptance_criterion|
-      = render 'acceptance_criterions/edit', user_story: user_story, acceptance_criterion: acceptance_criterion
+    %ul.criterions-list{ data: { url: reorder_criterions_path(user_story), user_story: user_story.id } }
+      - user_story.acceptance_criterions.each do |acceptance_criterion|
+        %li.criterion{ data: { id: acceptance_criterion.id,
+          criterion_order: acceptance_criterion.order } }
+          = render 'acceptance_criterions/edit', user_story: user_story, acceptance_criterion: acceptance_criterion
   .constraint-form
     = render 'constraints/new', user_story: user_story
-    - user_story.constraints.each do |constraint|
-      = render 'constraints/edit', user_story: user_story, constraint: constraint
+    %ul.constraints-list{ data: { url: reorder_constraints_path(user_story), user_story: user_story.id  } }
+      - user_story.constraints.each do |constraint|
+        %li.constraint{ data: { id: constraint.id,
+          constraint_order: constraint.order } }
+          = render 'constraints/edit', user_story: user_story, constraint: constraint
   .comment-form
     = render 'comments/new', user_story: user_story
     - if user_story.comments.count > 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,5 +74,15 @@ Railsroot::Application.routes.draw do
   post 'user_stories/copy', controller: :user_stories, action: :copy
   resources :goals, only: [:edit, :update, :destroy]
 
+  put 'user_stories/order_criterions',
+      controller: :user_stories,
+      action: :reorder_criterions,
+      as: :reorder_criterions
+
+  put 'user_stories/order_constraints',
+      controller: :user_stories,
+      action: :reorder_constraints,
+      as: :reorder_constraints
+
   devise_for :users, controllers: { registrations: 'registrations' }
 end

--- a/db/migrate/20151109125519_add_order_to_acceptance_criterion.rb
+++ b/db/migrate/20151109125519_add_order_to_acceptance_criterion.rb
@@ -1,0 +1,14 @@
+class AddOrderToAcceptanceCriterion < ActiveRecord::Migration
+  def change
+    add_column :acceptance_criterions, :order, :integer, index: true
+  end
+
+  def data
+    i = 1
+    AcceptanceCriterion.all.order(created_at: :asc).each do |acceptance_criterion|
+      acceptance_criterion.order = i
+      acceptance_criterion.save
+      i += 1
+    end
+  end
+end

--- a/db/migrate/20151109125635_add_order_to_constraint.rb
+++ b/db/migrate/20151109125635_add_order_to_constraint.rb
@@ -1,0 +1,14 @@
+class AddOrderToConstraint < ActiveRecord::Migration
+  def change
+    add_column :constraints, :order, :integer, index: true
+  end
+
+  def data
+    i = 1
+    Constraint.all.order(created_at: :asc).each do |constraint|
+      constraint.order = i
+      constraint.save
+      i += 1
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20151109183719) do
     t.integer  "user_story_id"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.integer  "order"
   end
 
   add_index "acceptance_criterions", ["user_story_id"], name: "index_acceptance_criterions_on_user_story_id", using: :btree
@@ -98,6 +99,7 @@ ActiveRecord::Schema.define(version: 20151109183719) do
     t.integer  "user_story_id",             null: false
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+    t.integer  "order"
   end
 
   add_index "constraints", ["description"], name: "index_constraints_on_description", using: :btree

--- a/spec/db/migrations/add_order_to_acceptance_criterion.rb
+++ b/spec/db/migrations/add_order_to_acceptance_criterion.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'migration_data/testing'
+require_migration 'add_order_to_acceptance_criterion'
+
+describe AddOrderToAcceptanceCriterion do
+  describe '#data' do
+    it 'works' do
+      expect { described_class.new.data }.to_not raise_exception
+    end
+  end
+end

--- a/spec/db/migrations/add_order_to_constraints.rb
+++ b/spec/db/migrations/add_order_to_constraints.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'migration_data/testing'
+require_migration 'add_order_to_constraint'
+
+describe AddOrderToConstraint do
+  describe '#data' do
+    it 'works' do
+      expect { described_class.new.data }.to_not raise_exception
+    end
+  end
+end

--- a/spec/features/project/constraints/create_constraint_spec.rb
+++ b/spec/features/project/constraints/create_constraint_spec.rb
@@ -48,7 +48,9 @@ feature 'Create a new constraint' do
   end
 
   scenario 'should show constraints in correct order', js: true do
-    constraints = create_list :constraint, 2, user_story: user_story
+    first_constraint = create :constraint, order: 1, user_story: user_story
+    second_constraint = create :constraint, order: 2, user_story: user_story
+    constraints = [first_constraint, second_constraint]
 
     visit current_path
     find('.user-story').click

--- a/spec/services/user_story_service_spec.rb
+++ b/spec/services/user_story_service_spec.rb
@@ -87,4 +87,46 @@ feature 'copy user story in other project' do
       expect(another_project.user_stories[index].estimated_points).to eq(user_story.estimated_points)
     end
   end
+
+  scenario 'should reorder acceptance criterions on user story' do
+    user_story = create :user_story
+    first_criterion, second_criterion, third_criterion = create_list :acceptance_criterion, 3, user_story: user_story
+    criterions = { 'criterions' => {
+                      '0' => {'id' => first_criterion.id, 'criterion_order' => 2},
+                      '1' => {'id' => second_criterion.id, 'criterion_order' => 3},
+                      '2' => {'id' => third_criterion.id, 'criterion_order' => 1}
+                    }
+                  }
+
+    acceptance_criterion_service = AcceptanceCriterionServices.new(user_story)
+    acceptance_criterion_service.reorder_criterions(criterions)
+
+    first_criterion_updated, second_criterion_updated, third_criterion_updated =
+    AcceptanceCriterion.find(first_criterion.id, second_criterion.id, third_criterion.id)
+
+    expect(first_criterion_updated.order).to eq 2
+    expect(second_criterion_updated.order).to eq 3
+    expect(third_criterion_updated.order).to eq 1
+  end
+
+  scenario 'should reorder constraints on user story' do
+    user_story = create :user_story
+    first_constraint, second_constraint, third_constraint = create_list :constraint, 3, user_story: user_story
+    constraints = { 'constraints' => {
+                      '0' => {'id' => first_constraint.id, 'constraint_order' => 2},
+                      '1' => {'id' => second_constraint.id, 'constraint_order' => 3},
+                      '2' => {'id' => third_constraint.id, 'constraint_order' => 1}
+                    }
+                  }
+
+    constraints_services = ConstraintServices.new(user_story)
+    constraints_services.reorder_constraints(constraints)
+
+    first_constraint_updated, second_constraint_updated, third_constraint_updated =
+    Constraint.find(first_constraint.id, second_constraint.id, third_constraint.id)
+
+    expect(first_constraint_updated.order).to eq 2
+    expect(second_constraint_updated.order).to eq 3
+    expect(third_constraint_updated.order).to eq 1
+  end
 end

--- a/spec/support/user_story_helper.rb
+++ b/spec/support/user_story_helper.rb
@@ -6,7 +6,7 @@ module UserStoryHelper
   def set_user_stories_on_project(project)
     create_list :user_story, 3, project: project
   end
-
+  
   def get_reordered(first_story, second_story, third_story)
     UserStory.find(first_story.id, second_story.id, third_story.id)
   end


### PR DESCRIPTION
## As a User I should be able to reorder an Acceptance Criteria and a Constraint so that I can organize them as I choose
#### Trello board reference:
- [Trello Card #233](https://trello.com/c/tSon2Zhc)

---
#### Description:
- Added drag & drop capabilities to acceptance criteria and to constraints

---
#### Reviewers:
- @damian @vico @rosina

---
#### Notes:
- There are some tests regarding other functionalities that are broken. But all the tests for this are working.

Checkout the migration gem used, as it gives us the chance to add migration tests, and migrate data very easily

---
#### Tasks:
- [x] Added order attributes to acceptance criterion and constraint model
- [x] Changed user story controller to order children using the new field
- [x] Modified services to update order attribute on each save
- [x] Added methods on services, and model to reorder entities
- [x] Assigned order able class to elements, creating a list for them
- [x] Modified _form view to make the drag and drop available
- [x] Modified js, added functionalities
- [x] Added migrations on tables and data
- [x] Provided migration tests
- [x] Provided feature tests

---
#### Risk:
- Medium

---
#### Preview:
- N/A
