### PR TITLE
Backlog comments on user stories

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -303,6 +303,7 @@
   }
 
   .acceptance-criterion-form,
+  .comment-form,
   .constraint-form {
     margin-bottom: rem-calc(5);
 
@@ -356,6 +357,27 @@
   }
 
   .estimation { padding-right: rem-calc(15); }
+
+  .comment-form {
+    .comment-user {
+      font-size: rem-calc(13);
+      font-weight: $font-weight-bold;
+      padding-top: rem-calc(15);
+
+      &:after {
+        color: $lab-color;
+        content: '\2022';
+        font-size: rem-calc(15);
+      }
+    } // user name
+
+    .comment-field {
+      border-bottom: 1px solid $black-10;
+      display: block;
+      font-size: rem-calc(14);
+      padding-bottom: rem-calc(15);
+    }
+  } // comment form
 } // backlog
 
 .backlog-placeholder {

--- a/app/views/comments/_form.haml
+++ b/app/views/comments/_form.haml
@@ -1,3 +1,3 @@
 = form_for(comment, remote: true) do |form|
-  = form.text_field :comment, class: 'backlog-placeholder', placeholder: t('backlog.user_stories.new_comment')
+  = form.text_area :comment, class: 'backlog-placeholder resizable-text-area', placeholder: t('backlog.user_stories.new_comment')
   = form.submit t('save'), id: 'save-comment', class: 'hide'

--- a/app/views/comments/_new.haml
+++ b/app/views/comments/_new.haml
@@ -1,1 +1,2 @@
+.criterion-group= t('backlog.comments')
 = render 'comments/form', comment: [user_story, Comment.new]

--- a/app/views/user_stories/_form.haml
+++ b/app/views/user_stories/_form.haml
@@ -80,6 +80,7 @@
     = render 'comments/new', user_story: user_story
     - if user_story.comments.count > 0
       - user_story.comments.each do |comment|
-        .row
-          = comment.comment
+        .comment-user
           = t('backlog.user_stories.comment_user', user: comment.user_name)
+        .comment-field
+          = comment.comment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,14 +104,15 @@ en:
       no_stories: "There are not stories selected to be copied."
       stories_copied: "The stories are copied successfully."
       new_tag: 'Create a new tag here'
-      new_comment: 'Leave a new comment here'
-      comment_user: "By %{user}"
+      new_comment: "Write a new comment here..."
+      comment_user: "%{user}"
       destination_project: "Select destination project"
     story_span: "Story"
     logout: "Sign out"
     acceptance_criterions: "Acceptance Criteria"
     constraints: "Constraints"
-    tags: 'Tags'
+    tags: "Tags"
+    comments: "Comments"
   canvas:
     textarea_placeholder: "Click here to enter text"
   attachment:


### PR DESCRIPTION
## Style new Comment feature on Backlog
#### Trello board reference:
- [Trello Card #229](https://trello.com/c/e4xhC4ch/229-229-3-as-a-collaborator-i-should-be-able-to-comment-on-a-user-story-so-that-i-can-leave-feedback-for-other-collaborators)

---
#### Description:
- Styles new feature that allows the user to post comments on user stories.

---
#### Reviewers:
- @damian

---
#### Tasks:
- [x] Apply resizable-textarea class to placeholder
- [x] Add bullet after user name
- [x] Change text style on inputs
- [x] Delete "Added by" text on internationalization
- [x] Correct placeholder's copy

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-11-11 at 3 56 03 p m](https://cloud.githubusercontent.com/assets/6147409/11099974/2a67f382-888d-11e5-87f6-2890c2c17b15.png)
