### PR TITLE
Story/2 only see save button on canvas when editing field

### DIFF
--- a/app/assets/javascripts/assets/customTextArea.js
+++ b/app/assets/javascripts/assets/customTextArea.js
@@ -18,4 +18,13 @@ function CustomTextArea() {
       return false;
     }
   });
+
+  $('.resizable-text-area').focus(function(){
+    $('#save-canvas').show();
+  });
+
+  $('.resizable-text-area').blur(function(){
+    $('#save-canvas').hide();
+  });
+
 }

--- a/app/assets/stylesheets/_canvas.scss
+++ b/app/assets/stylesheets/_canvas.scss
@@ -89,6 +89,8 @@
       }
     } // textarea
 
+    #save-canvas { display: none; }
+
     .enter {
       color: $font-color-3;
       display: none;

--- a/spec/features/project/canvas/change_canvas_questions_spec.rb
+++ b/spec/features/project/canvas/change_canvas_questions_spec.rb
@@ -12,7 +12,7 @@ feature 'Canvas question change for each canvas step' do
   scenario 'should stay on the answered question' do
     visit project_canvases_path(project)
     find('.solutions-field textarea').set('My solution proposal')
-    click_button 'save-canvas'
+    find('#save-canvas', visible: false).click
     within '.right-content-wrapper' do
       expect(page).to have_text(I18n.t('solutions_title'))
       expect(page).to have_text('My solution proposal')
@@ -80,5 +80,12 @@ feature 'Canvas question change for each canvas step' do
     find(".canvas-item[type='cost-structure']").click()
     question = 'What are your customer acquisition costs, distribution costs, people, hosting, integration partners, etc?'
     expect(find('.cost-structure-field label')).to have_content(question)
+  end
+
+  scenario 'save button remains hidden until textarea gains focus', js: true do
+    visit project_canvases_path(project)
+    expect(page).to have_selector('#save-canvas', visible: false)
+    find('.resizable-text-area').click
+    expect(page).to have_selector('#save-canvas', visible: true)
   end
 end

--- a/spec/features/project/canvas/change_value_proposition_spec.rb
+++ b/spec/features/project/canvas/change_value_proposition_spec.rb
@@ -15,7 +15,7 @@ feature 'Edit value proposition' do
     find(".canvas-item[type='value-proposition']").click()
     updated_proposition = 'My new value proposition'
     fill_in :value_proposition, with: updated_proposition
-    find('#save-canvas').click()
+    find('#save-canvas', visible: false).click
     visit project_hypotheses_path(project_id: project.id)
     expect(find(hypothesis_title)).to have_text(updated_proposition)
   end

--- a/spec/features/project/canvas/completed_percentage_spec.rb
+++ b/spec/features/project/canvas/completed_percentage_spec.rb
@@ -29,7 +29,7 @@ feature 'Change complete percentage' do
     sign_in member
     visit project_canvases_path(project)
     find('.problems-field textarea').set('My problem proposal')
-    click_button 'save-canvas'
+    find('#save-canvas', visible: false).click
     expect(find('.percentage span')).to have_text('11%')
   end
 end


### PR DESCRIPTION
## As a User, I should be able to only see the "Save Button" on Canvas, when editing the field, so that I can just focus on the text
#### Trello board reference:
- [Trello Card #2](https://trello.com/c/lnIZ8uHe)

---
#### Description:
- Only show save button when text area gains focus.

---
#### Reviewers:
- @damian @rosina

---
#### Notes:
- 

---
#### Tasks:
- [x] Add display none by default on canvas view for submit button
- [x] Add js function to show button on text area focus ,and hide it again on txt area blur
- [x] Provide / Fix feature tests

---
#### Risk:
- Medium

---
#### Preview:

![card-2](https://cloud.githubusercontent.com/assets/11840705/11214220/c54ba0b6-8d1e-11e5-9acc-220997a06c55.gif)
