### PR TITLE
Story/266 changing a an accordingly

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,18 +16,6 @@
 //= require hypotheses/userStory
 //= require hypotheses/goal
 //= require userStories/userStories
+//= require userStories/a_an_grammar
 //= require_tree ./vendor
 //= require_tree ./attachments
-
-
-/*
-
-Only on Safari this kind of constructor exists
-
-An unique naming pattern in its naming of constructors.
-This is the least durable method of all listed properties, because it's undocumented.
-On the other hand, there's no benefit in renaming the constructor,
-so it's likely to stay for a long while.
-
-*/
-var is_safari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0;

--- a/app/assets/javascripts/assets/global-vars.js
+++ b/app/assets/javascripts/assets/global-vars.js
@@ -6,3 +6,14 @@ var mobiles     = (/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.u
 var is_mobile   = mobiles ? true : false;
 var body_height = $('body').height();
 var html_height = $('html').height();
+/*
+
+Only on Safari this kind of constructor exists
+
+An unique naming pattern in its naming of constructors.
+This is the least durable method of all listed properties, because it's undocumented.
+On the other hand, there's no benefit in renaming the constructor,
+so it's likely to stay for a long while.
+
+*/
+var is_safari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0;

--- a/app/assets/javascripts/hypotheses/userStory.js
+++ b/app/assets/javascripts/hypotheses/userStory.js
@@ -102,6 +102,7 @@ function UserStory() {
 
         var $userStoryForm = $('#edit_user_story_' + userStoryId);
         $appContent.scrollTo($userStoryForm, 200);
+        fixArticlesForRolesOnLab();
     });
   }
 

--- a/app/assets/javascripts/userStories/a_an_grammar.js
+++ b/app/assets/javascripts/userStories/a_an_grammar.js
@@ -1,0 +1,92 @@
+// Bind key events to user roles being typed live, Ale
+$('#user_story_role.role').on('keydown keyup', function(e) {
+  prependGramaticallyCorrectArticle(this);
+});
+
+// On document ready
+$(document).ready(function() {
+  fixArticlesForRolesOnLab();
+  fixArticlesForRolesOnBacklog();
+});
+
+function fixArticlesForRolesOnLab(){
+  // for lab, look for articles and fix them accordingly, Ale
+  if ($('.hypothesis').length > 0) {
+    $('.role').each(function(index, currentValue) {
+      if (currentValue.children.length > 0 &&
+          currentValue.children[1].tagName == 'INPUT') {
+        prependGramaticallyCorrectArticle(currentValue.children[1]);
+      }
+    });
+  }
+};
+
+function fixArticlesForRolesOnBacklog(){
+  // for backlog, look for articles and fix them accordingly, Ale
+  if ($('.user-stories').length > 0) {
+    $('.story-text').each(function(index, currentValue) {
+      if (currentValue.children.length &&
+          currentValue.children[1].tagName == 'SPAN') {
+        prependGramaticallyCorrectArticle(currentValue.children[1]);
+      }
+    });
+  }
+};
+
+function prependGramaticallyCorrectArticle(element){
+  var article = 'a',
+      textToArticleize = (element.tagName == 'SPAN') ? element.textContent : element.value;
+
+  element.parentNode.children[0].textContent = 'As ' + article;
+  if (textToArticleize.length > 0) {
+    article = indefiniteArticle(textToArticleize);
+    element.parentNode.children[0].textContent = 'As ' + article;
+  }
+}
+
+var indefiniteArticle = function(word) {
+  var l_word = word.toLowerCase(),
+      alternativeCases = [],
+      regexes = [/^e[uw]/, /^onc?e\b/, /^uni([^nmd]|mo)/, /^u[bcfhjkqrst][aeiou]/],
+      toReturn;
+
+  // Single letter word which should be preceeded by 'an'
+  toReturn = (l_word.length == 1 && 'aedhilmnorsx'.indexOf(l_word) > -1 ) ? 'an' : 'a';
+
+  // Capital words which should likely be preceeded by 'an'
+  if (word.match(/(?!FJO|[HLMNS]Y.|RY[EO]|SQU|(F[LR]?|[HL]|MN?|N|RH?|S[CHKLMNPTVW]?|X(YL)?)[AEIOU])[FHLMNRSX][A-Z]/)) {
+    toReturn = 'an';
+  }
+
+  // Special cases where a word that begins with a vowel should be preceeded by 'a'
+
+  $.each(regexes, function(index, currentRegEx){
+    if (l_word.match(currentRegEx)) toReturn = 'a';
+  });
+
+  // Special capital words (UK, UN)
+  if (word.match(/^U[NK][AIEO]/)) {
+    toReturn = 'a';
+  }
+  else if (word == word.toUpperCase()) {
+    toReturn = ('aedhilmnorsx'.indexOf(l_word[0]) > -1) ? 'an' : 'a';
+  }
+
+  // Basic method of words that begin with a vowel being preceeded by 'an'
+  if ('aeiou'.indexOf(l_word[0]) > -1) toReturn = "an";
+
+  // Instances where y follwed by specific letters is preceeded by 'an'
+  if (l_word.match(/^y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)/)) toReturn = 'an';
+
+  // Specific words that should be preceeded by 'a'
+  alternativeCases = ['user'];
+  if (alternativeCases.indexOf(l_word) > -1) toReturn = 'a';
+
+  // Specific start of words that should be preceeded by 'an'
+  alternativeCases = ['honest', 'hour', 'hono', 'x-'];
+  $.each(alternativeCases, function(index, currentValue){
+    if(currentValue == l_word.substring(0, currentValue.length)) toReturn = 'an';
+  });
+
+  return toReturn;
+};

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -40,7 +40,7 @@ function UserStories() {
   function bindRemoveTag() {
     $('.applied-tag').click(function(e) {
       if (e.shiftKey) return;
-      
+
       var tag_to_remove = $(this).text().trim(),
           index = selectedTags.indexOf(tag_to_remove);
       if (index > -1) {
@@ -266,6 +266,7 @@ function UserStories() {
         $userStoriesOnList.removeClass('selected');
         $("[data-url='" + editUrl + "']").addClass('selected');
       }
+      fixArticlesForRolesOnBacklog();
     });
   }
 
@@ -438,7 +439,6 @@ function UserStories() {
 
   function bindUserStoryEditForm() {
     $editUserStoryForm = $('form.edit-story.edit_user_story');
-
     $editUserStoryForm.submit(function() {
       var url       = $(this).attr('action'),
           type      = $(this).attr('method'),
@@ -460,6 +460,13 @@ function UserStories() {
         $this.hide();
         $span.html($this.val());
       }
+
+      // correct articles when saved client story get clicked on backlog, Ale
+      prependGramaticallyCorrectArticle(this);
+      // bind key events for the new edit form to be created, Ale
+      $('.edit-story .row #user_story_role.role').on('keydown keyup', function(e) {
+        prependGramaticallyCorrectArticle(this);
+      });
     });
   }
 

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -268,6 +268,8 @@
       margin-top: rem-calc(30);
       padding-top: rem-calc(20);
     }
+
+    .role-a-an { display: inline; }
   } // user story edit form
 
   .edit-backlog-inputs:hover .icon-trash { @include opacity(1); }

--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -264,6 +264,8 @@
       }
 
       .user-story-priority { display: inline; }
+
+      .role-a-an { display: inline; }
     }
   }
 

--- a/app/views/user_stories/_form.haml
+++ b/app/views/user_stories/_form.haml
@@ -12,7 +12,7 @@
       = "##{user_story.story_number}"
   .row
     .user-story-input.role
-      = t('backlog.user_stories.role')
+      .role-a-an= t('backlog.user_stories.role')
       %span.show-role{ title: t('backlog.user_stories.edit_role') }
       = form.text_field(                                   |
         :role,                                             |

--- a/app/views/user_stories/_lab_form.haml
+++ b/app/views/user_stories/_lab_form.haml
@@ -9,7 +9,7 @@ url: form_url do |form|
           %li= error
   %span
   .user-story-input.role
-    = t('backlog.user_stories.role')
+    .role-a-an= t('backlog.user_stories.role')
     = form.text_field(                                   |
       :role,                                             |
       placeholder: t('backlog.user_stories.enter_role'), |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
       enter_role: "<type of user>"
       enter_action: "<some function>"
       enter_result: "<some benefit>"
-      role: "As a/an"
+      role: "As a"
       action_prefix: "I"
       action_suffix: "be able to"
       action: "I %{priority} be able to"

--- a/spec/features/project/hypothesis/edit_spec.rb
+++ b/spec/features/project/hypothesis/edit_spec.rb
@@ -32,4 +32,16 @@ feature 'Edit hypothesis' do
       expect(find('.hypothesis-title')).to have_text updated_title
     end
   end
+
+  scenario 'when editing user role the article should be correct', js: true do
+    find('.hypothesis-show').click
+    find('#user_story_role').native.send_keys('a','d','m','i','n')
+    expect(find('.role-a-an').text).to eq('As an')
+
+    visit project_hypotheses_path(project.id)
+    
+    find('.hypothesis-show').click
+    find('#user_story_role').native.send_keys('u','s','e','r')
+    expect(find('.role-a-an').text).to eq('As a')
+  end
 end

--- a/spec/features/project/user_story/create_user_story_spec.rb
+++ b/spec/features/project/user_story/create_user_story_spec.rb
@@ -54,6 +54,16 @@ feature 'Create a new user story' do
         expect{ click_button 'Save' }.to change{ UserStory.count }.from(0).to(1)
       end
     end
+
+    scenario 'on lab should use the correct article on the role label', js: true do
+      find('#user_story_role').native.send_keys('a','d','m','i','n')
+      expect(find('.role-a-an').text).to eq('As an')
+
+      visit current_path
+
+      find('#user_story_role').native.send_keys('u','s','e','r')
+      expect(find('.role-a-an').text).to eq('As a')
+    end
   end
 
   context 'backlog section' do

--- a/spec/features/project/user_story/list_user_stories_spec.rb
+++ b/spec/features/project/user_story/list_user_stories_spec.rb
@@ -55,6 +55,18 @@ feature 'List user stories' do
         end
       end
     end
+
+    scenario 'should show the correct article for the user type assigned', js: true  do
+      visit project_hypotheses_path project
+
+      within "#edit_user_story_#{UserStory.first.id}" do
+        expect(find('.role-a-an').text).to eq 'As a'
+      end
+
+      within "#edit_user_story_#{UserStory.second.id}" do
+        expect(find('.role-a-an').text).to eq 'As an'
+      end
+    end
   end
 
   context 'backlog section' do
@@ -123,6 +135,18 @@ feature 'List user stories' do
 
       points_field = find ".user-story[data-id='#{UserStory.first.id}'] .points"
       expect(points_field.text).to be_empty
+    end
+
+    scenario 'should show the correct article for the user type assigned', js: true  do
+      visit project_user_stories_path project
+
+      within "li.user-story[data-id='#{UserStory.first.id}']" do
+        expect(find('.story-text').text).to have_content('As a')
+      end
+
+      within "li.user-story[data-id='#{UserStory.second.id}']"  do
+        expect(find('.story-text').text).to have_content('As an')
+      end
     end
   end
 end

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe UserStory do
     let(:entity) do
       build :user_story, role: 'User', action: 'work', result: 'test'
     end
-    let(:description) { 'As a/an User I should be able to work so that test' }
+    let(:description) { 'As a User I should be able to work so that test' }
   end
 
   describe 'story_number' do


### PR DESCRIPTION
## As a User, when I type the role for a user story I should be able to see the 'a/an' change accordingly.
#### Trello board reference:
- [Trello Card #266](https://trello.com/c/rvozHhZi)

---
#### Description:
- It should change when typing as well as for the saved ones.

---
#### Reviewers:
- @vico @pgonzaga @damian @rosina

---
#### Notes:
- I've used this PR as well to put the is_safari variable in the correct js file.

---
#### Tasks:
- [x] Created js for applying the correct article depending on user type
- [x] Binded function on type user keypress
- [x] Binded function on document ready
- [x] Added class to role tag
- [x] Provided tests

---
#### Risk:
- Medium

---
#### Preview:

![card266](https://cloud.githubusercontent.com/assets/11840705/11247482/0d041dac-8dfb-11e5-991b-6d6997e4227e.gif)
