### PR TITLE
Fix textarea's height on Backlog

### DIFF
--- a/app/assets/javascripts/assets/customTextArea.js
+++ b/app/assets/javascripts/assets/customTextArea.js
@@ -1,7 +1,7 @@
 function CustomTextArea() {
   var resizeTextarea = function(el) {
     var offset = el.offsetHeight - el.clientHeight;
-    $(el).css('height', 'auto').css('height', el.scrollHeight + offset);
+    $(el).css('height', '10px').css('height', el.scrollHeight + offset);
   };
 
   $('.resizable-text-area').each(function() {

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -396,7 +396,7 @@
     color: $black-40;
     font-size: rem-calc(15);
     font-style: italic;
-    line-height: .8;
+    line-height: .5;
     padding: rem-calc(5 0);
   };
 } // backlog placeholders


### PR DESCRIPTION
## Fix textarea's height on focus
#### Trello board reference:
- [Trello Card #229](https://trello.com/c/e4xhC4ch/229-229-3-as-a-collaborator-i-should-be-able-to-comment-on-a-user-story-so-that-i-can-leave-feedback-for-other-collaborators)

---
#### Description:
- Fixes textarea's height on focus which was too large

---
#### Reviewers:
- @doshii  

---
#### Tasks:
- [x] Change 'auto' value into 15px on customTextArea.js

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/11279675/aef4d9f0-8ed0-11e5-9cd7-425f4e71dbb0.gif)
