### PR TITLE
Add styles for comment date

### DIFF
--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -370,6 +370,7 @@
 
   .comment-form {
     .comment-user {
+      @include inline-block;
       font-size: rem-calc(13);
       font-weight: $font-weight-bold;
       padding-top: rem-calc(15);
@@ -387,6 +388,14 @@
       font-size: rem-calc(14);
       padding-bottom: rem-calc(15);
     }
+
+    .action-time {
+      @include inline-block;
+      border: 0;
+      color: $black-40;
+      cursor: default;
+      font-size: rem-calc(13);
+    } // comment date
   } // comment form
 } // backlog
 


### PR DESCRIPTION
## Style date comment on Backlog
#### Trello board reference:
- [Trello Card #229](https://trello.com/c/e4xhC4ch/229-229-3-as-a-collaborator-i-should-be-able-to-comment-on-a-user-story-so-that-i-can-leave-feedback-for-other-collaborators)

---
#### Description:
- Gives style to the date the user made the comment on the Backlog

---
#### Reviewers:
- @damian

---
#### Notes:
- 

---
#### Tasks:
- [x] Style date
- [x] Put inline-block property to user name

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2015-11-20 at 12 17 36 p m](https://cloud.githubusercontent.com/assets/6147409/11303251/b48d7e8e-8f80-11e5-98d5-472809dae040.png)
