### PR TITLE
Add restriction to view project to no members

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,7 @@ class ProjectsController < ApplicationController
   before_action :load_project,
                 only: [:show, :edit, :update, :destroy,
                        :log, :export_to_spreadhseet]
+  before_action :check_edit_permission, only: :show
 
   def index
   end
@@ -133,5 +134,13 @@ class ProjectsController < ApplicationController
 
   def update_order_params
     params.require(:stories)
+  end
+
+  def check_edit_permission
+    project_auth = ProjectAuthorization.new(@project)
+    return if project_auth.member?(current_user)
+
+    flash[:alert] = I18n.translate('can_not_edit')
+    redirect_to root_url
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -45,4 +45,32 @@ RSpec.describe ProjectsController do
       end
     end
   end
+
+  describe 'GET show' do
+    let!(:user)       { create :user }
+    let!(:no_member)  { create :user }
+    let!(:project)    { create :project, owner: user }
+
+    context 'when the user is a project member' do
+      before :each do
+        sign_in user
+      end
+
+      it 'should be success' do
+        get :show, id: project.id
+        expect(response).to be_success
+      end
+    end
+
+    context 'when user is not a project member' do
+      before :each do
+        sign_in no_member
+      end
+
+      it 'should redirect the user' do
+        get :show, id: project.id
+        expect(response).to be_redirect
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Ensure that nonmembers of a project can't access to it
#### Trello board reference:
- [Trello Card #291](https://trello.com/c/UF3VbrNi/291-291-ensure-that-nonmembers-of-a-project-can-t-access-to-it)

---
#### Description:
- We discover that no members can access to project edit view so we decide to fix it

---
#### Reviewers:
- @oscarsiniscalchi @Vico @AlejandroFernandesAntunes

---
#### Notes:
- 

---
#### Tasks:
- [x] Add restriction on project controller

---
#### Risk:
- Medium

---
#### Preview:
- N/A
