### PR TITLE
Correct js so the alert box appears only one time if textarea is empty

### DIFF
--- a/app/assets/javascripts/assets/customTextArea.js
+++ b/app/assets/javascripts/assets/customTextArea.js
@@ -1,4 +1,5 @@
 function CustomTextArea() {
+  var errorsToControl = ["Description can't be blank"]
   var resizeTextarea = function(el) {
     var offset = el.offsetHeight - el.clientHeight;
     $(el).css('height', '10px').css('height', el.scrollHeight + offset);
@@ -13,8 +14,12 @@ function CustomTextArea() {
 
   $('.resizable-text-area').off('keypress').on('keypress', function(e) {
     if(e.keyCode === 13 ) {
-      $(this.form).submit();
-      resizeTextarea(this);
+      if($(this).text() == "") {
+        if($('.alert-box.error').text().indexOf("can't be blank") == -1) {
+          $(this.form).submit();
+          resizeTextarea(this);
+        }
+      }
       return false;
     }
   });

--- a/app/views/user_stories/index.pdf.haml
+++ b/app/views/user_stories/index.pdf.haml
@@ -1,46 +1,47 @@
-- canvas = @project.canvas
-%section.canvas
-  %div.section-title
-    .section-icon= render 'shareable/svg/canvas_icon'
-    %h2.title-text Canvas
+- if @project.canvas.present?
+  - canvas = @project.canvas
+  %section.canvas
+    %div.section-title
+      .section-icon= render 'shareable/svg/canvas_icon'
+      %h2.title-text Canvas
 
-  %ul.pdf-canvas-item-list
-    - if canvas.problems.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('problems')
-        .description= canvas.problems
-    - if canvas.solutions.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('solutions')
-        .description= canvas.solutions
-    - if canvas.alternative.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('alternative')
-        .description= canvas.alternative
-    - if canvas.advantage.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('advantage')
-        .description= canvas.advantage
-    - if canvas.segment.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('segment')
-        .description= canvas.segment
-    - if canvas.channel.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('channel')
-        .description= canvas.channel
-    - if canvas.value_proposition.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('value_proposition')
-        .description= canvas.value_proposition
-    - if canvas.revenue_streams.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('revenue_streams')
-        .description= canvas.revenue_streams
-    - if canvas.cost_structure.present?
-      %li.pdf-canvas-item
-        .uppercase-subtitle=t('cost_structure')
-        .description= canvas.cost_structure
+    %ul.pdf-canvas-item-list
+      - if canvas.problems.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('problems')
+          .description= canvas.problems
+      - if canvas.solutions.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('solutions')
+          .description= canvas.solutions
+      - if canvas.alternative.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('alternative')
+          .description= canvas.alternative
+      - if canvas.advantage.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('advantage')
+          .description= canvas.advantage
+      - if canvas.segment.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('segment')
+          .description= canvas.segment
+      - if canvas.channel.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('channel')
+          .description= canvas.channel
+      - if canvas.value_proposition.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('value_proposition')
+          .description= canvas.value_proposition
+      - if canvas.revenue_streams.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('revenue_streams')
+          .description= canvas.revenue_streams
+      - if canvas.cost_structure.present?
+        %li.pdf-canvas-item
+          .uppercase-subtitle=t('cost_structure')
+          .description= canvas.cost_structure
 
 
 %section.backlog


### PR DESCRIPTION
## Fix js to prevent error messages appearing as many times as I hit enter on empty textarea
#### Trello board reference:
- [Trello Card #248](https://trello.com/c/6890oJhd/248-when-entering-a-new-ac-or-constraint-if-hitting-enter-several-times-will-append-error-messages-as-many-times-as-enter-is-hit)

---
#### Description:
- Fix js to prevent error messages appearing as many times as I hit enter on empty textareas on Backlog.

---
#### Reviewers:
- @damian

---
#### Tasks:
- [x] If textarea is empty, error message will be displayed only once

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/11346243/70aaad3c-91fa-11e5-8843-f87f1c427233.gif)
