### PR TITLE
Fix trash-icon position & hypothesis width

### DIFF
--- a/app/assets/stylesheets/_labs_section.scss
+++ b/app/assets/stylesheets/_labs_section.scss
@@ -65,6 +65,7 @@
       @include opacity(0);
       left: auto;
       right: 0;
+      top: 0;
       z-index: 2;
 
       &:hover { color: $black-40; }
@@ -281,6 +282,7 @@
     .hypothesis-title {
       @include single-transition(color, .25s, ease-in);
       cursor: text;
+      width: 97%;
 
       &:hover { color: $font-color-3; }
 


### PR DESCRIPTION
## Correct trash-icon position on Hypothesis title
#### Trello board reference:
- [Trello Card #280](https://trello.com/c/OMW9lN3L/280-280-if-the-hypothesis-text-covers-all-the-line-it-overlaps-with-the-trash-icon)

---
#### Description:
- Hypothesis title had 100% width so once you hover on it, the trash icon looked overlapped.

---
#### Reviewers:
- @doshii 

---
#### Tasks:
- [x] Fix Hypothesis title width
- [x] Put top position value to trash-icon

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/11380702/7a51058e-92d6-11e5-8410-8f344897a2dd.gif)
