### PR TITLE
Make Activity view a non-modal view

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -157,23 +157,6 @@ $('select#user_story_priority').on('change', function() {
   $(this).closest('form#new_user_story').find('.user-story-priority').text(this.value);
 });
 
-$('#log-modal').on('opened.fndtn.reveal', function() {
-  var $modal_height = $('#log-modal').height();
-
-  $('#log-modal').on('scroll', function() {
-    var active_pages = $('#log .active.log-page').size()
-        inactive_pages = $('#log .inactive.log-page').size(),
-        number_pages = active_pages + inactive_pages,
-        pages_left = number_pages - inactive_pages > 0,
-        log_height = $('#log').height(),
-        scroll_from_top = $('#log-modal').scrollTop();
-
-    if (pages_left && scroll_from_top > log_height - $modal_height ) {
-      $('#log .inactive.log-page').first().toggleClass('active inactive');
-    }
-  });
-});
-
 $('.hypothesis input')
   .focus(function() {
     $(this).closest('.row').addClass('editing');

--- a/app/assets/stylesheets/_log.scss
+++ b/app/assets/stylesheets/_log.scss
@@ -1,7 +1,7 @@
 #log {
   .log-page {
     &.active { display: block; }
-    &.inactive { display: none; }
+    &.inactive { display: block; }
 
     .log-entry {
 
@@ -15,3 +15,5 @@
     }
   }
 } // log
+
+.content-general { overflow: scroll; }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,8 +69,6 @@ class ProjectsController < ApplicationController
   def log
     project_services = ProjectServices.new(@project)
     @activities_by_pages = project_services.activities_by_pages
-
-    render layout: false
   end
 
   def backlog

--- a/app/views/layouts/_sidebar.haml
+++ b/app/views/layouts/_sidebar.haml
@@ -47,7 +47,7 @@
             = render 'shareable/svg/members_icon'
             = t('sidebar.members')
         %li
-          = link_to log_project_path(current_project), { data: { reveal_id: 'log-modal', reveal_ajax: true }, class: 'activity-link' } do
+          = link_to log_project_path(current_project) do
             = render 'shareable/svg/activity_icon'
             = t('sidebar.activity')
   %ul.footer
@@ -61,4 +61,3 @@
         = t('sidebar.version') + ENV['SIDEBAR_VERSION']
       = link_to '#', title: t('sidebar.collapse'), class: 'collapse' do
         %span.icon-left
-#log-modal.reveal-modal{ data: { reveal: '' } }

--- a/app/views/projects/log.haml
+++ b/app/views/projects/log.haml
@@ -1,6 +1,4 @@
 %div#log
-  - @activities_by_pages.each_with_index do |activity_page, index|
-    %div.log-page{ id: "log_page_#{index}", class: "#{index > 0 ? 'inactive' : 'active'}" }
+  - @activities_by_pages.each_with_index do |activity_page|
+    %div.log-page{ id: 'log_page', class: 'active' }
       = render 'log_page', page_activities: activity_page
-
-

--- a/spec/features/project/lab_log_spec.rb
+++ b/spec/features/project/lab_log_spec.rb
@@ -225,38 +225,6 @@ feature 'Log lab activity' do
         activities = PublicActivity::Activity.all
         expect(activities.count).to eq 22
       end
-
-      scenario 'should paginate the log entries in 3 pages' do
-        expect(all('#log .log-page').count).to eq 3
-      end
-
-      scenario 'should only show the first page at the beginning' do
-        expect(all('#log .active.log-page').count).to eq 1
-      end
-
-      scenario 'should hide the other 2 pages' do
-        expect(all('#log .inactive.log-page').count).to eq 2
-      end
-
-      scenario 'should only show 8 entries at first' do
-        expect(all('#log .active.log-page .log-entry').count).to eq 8
-      end
-
-      scenario 'should hide the other 14 entries' do
-        expect(all('#log .inactive.log-page .log-entry').count).to eq 14
-      end
-
-      scenario 'should have 8 entries on the second page' do
-        expect(
-          all('#log .inactive.log-page#log_page_1 .log-entry').count
-        ).to eq 8
-      end
-
-      scenario 'should only have 6 entries on the third page' do
-        expect(
-          all('#log .inactive.log-page#log_page_2 .log-entry').count
-        ).to eq 6
-      end
     end
   end
 end


### PR DESCRIPTION
## As a User I want to view "Activity" as it's own screen so that I don't have to see it in a small pop-up overlay window
#### Trello board reference:
- [Trello Card #272](https://trello.com/c/cUD2ht4Y)

---
#### Description:
- As a User I want to view "Activity" as it's own screen so that I don't have to see it in a small pop-up overlay window

---
#### Reviewers:
- @vico @rosina @damian

---
#### Notes:
- 

---
#### Tasks:
- [x] Remove modal from view
- [x] Add overflow scroll on new view
- [x] Remove unneeded js

---
#### Risk:
- Medium

---
#### Preview:
- N/A
