### PR TITLE
Disable form when click on Copy user stories feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,5 +17,6 @@
 //= require hypotheses/goal
 //= require userStories/userStories
 //= require userStories/a_an_grammar
+//= require userStories/disableArea
 //= require_tree ./vendor
 //= require_tree ./attachments

--- a/app/assets/javascripts/userStories/disableArea.js
+++ b/app/assets/javascripts/userStories/disableArea.js
@@ -1,0 +1,23 @@
+$('#select_stories_lnk').click(function()  {
+  var form = document.getElementById('new_user_story');
+      filterVal = 'blur(3px)';
+  $(form).addClass('disabled-items');
+
+  $('.user-story-edit-form')
+   .css('filter',filterVal)
+   .css('webkitFilter',filterVal)
+   .css('mozFilter',filterVal)
+   .css('oFilter',filterVal)
+   .css('msFilter',filterVal);
+
+  $(form.elements).each(function(index, currentValue) {
+    //iterate over elements on the form, Rosina
+    $(currentValue).attr('readonly', true);
+  });
+
+  var idElementsToDisable = ['#user_story_estimated_points', '#user_story_priority'];
+  for (var i = 0; i < idElementsToDisable.length; i++){
+    $(idElementsToDisable[i]).hide();
+    $(idElementsToDisable[i]).css('cursor', 'pointer');
+  }
+});

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -132,3 +132,10 @@ input[type="password"] {
   font-size: rem-calc(12);
   text-transform: uppercase;
 }
+
+.disabled-items {
+  @include non-selectable-text;
+  cursor: default;
+
+  label { cursor: default; }
+}

--- a/app/assets/stylesheets/assets/_base.scss
+++ b/app/assets/stylesheets/assets/_base.scss
@@ -29,3 +29,10 @@
   cursor: -ms-grabbing;
   cursor: grabbing;
 }
+
+@mixin non-selectable-text {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
## Disable user story form on copy mode
#### Trello board reference:
- [Trello Card #228](https://trello.com/c/ZbtTuDX5/228-228-3-while-in-the-backlog-copy-mode-if-the-displayed-story-is-modified-the-list-is-refreshed-but-the-links-on-top-remain-the-sa)

---
#### Description:
- Disables the capability to enter new user stories when entering copy mode.

---
#### Reviewers:
- @damian

---
#### Tasks:
- [x] Add js to make the form only readable when entering the user story copy mode
- [x] Add blur  filter to text
- [x] Add mixin for making text non selectable

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/11407172/c7ff1b40-938f-11e5-96e5-47164dd9e413.gif)
