### PR TITLE
Fix js so the error message is displayed only one

### DIFF
--- a/app/assets/javascripts/assets/customTextArea.js
+++ b/app/assets/javascripts/assets/customTextArea.js
@@ -1,5 +1,4 @@
 function CustomTextArea() {
-  var errorsToControl = ["Description can't be blank"]
   var resizeTextarea = function(el) {
     var offset = el.offsetHeight - el.clientHeight;
     $(el).css('height', '10px').css('height', el.scrollHeight + offset);
@@ -8,18 +7,13 @@ function CustomTextArea() {
   $('.resizable-text-area').each(function() {
     $(this).height( 0 );
     $(this).height( this.scrollHeight );
-
     $(this).on('keyup input', function() { resizeTextarea(this); });
   });
 
   $('.resizable-text-area').off('keypress').on('keypress', function(e) {
     if(e.keyCode === 13 ) {
-      if($(this).text() == "") {
-        if($('.alert-box.error').text().indexOf("can't be blank") == -1) {
-          $(this.form).submit();
-          resizeTextarea(this);
-        }
-      }
+      $(this.form).submit();
+      resizeTextarea(this);
       return false;
     }
   });

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -292,7 +292,7 @@ function UserStories() {
         if(response.status === 422) {
           var $errors = $.parseJSON(response.responseText).errors,
               $errorsContainer = $('.user-story-component-error');
-          $errorsContainer.append($errors);
+          if ($errorsContainer.text().indexOf($errors) < 0) $errorsContainer.append($errors);
           $errorsContainer.show();
           refreshBacklog();
         }


### PR DESCRIPTION
## Fixes js so the alert-box appears only one time
#### Trello board reference:
- [Trello Card #248](https://trello.com/c/6890oJhd/248-248-2-when-entering-a-new-ac-or-constraint-if-hitting-enter-several-times-will-append-error-messages-as-many-times-as-enter-is-h)

---
#### Description:
- Alert box doesn't appear duplicated anymore

---
#### Reviewers:
- @ale

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/11428979/3b991d10-9450-11e5-8af9-cb6aad9c8dee.gif)
