### PR TITLE
Fix for description empty on hypothesis not showing error bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,5 +19,6 @@
 //= require userStories/archive
 //= require userStories/a_an_grammar
 //= require userStories/disableArea
+//= require lab/lab
 //= require_tree ./vendor
 //= require_tree ./attachments

--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -106,6 +106,24 @@ function collapseSidebar() {
   }
 }
 
+// html5 validation copycat, Ale
+function preSubmitForm(obj) {
+  var requiredFields = $('#'+obj.form.id).find(":input[required= 'required']").serializeArray();
+      isItOk = true;
+      message = 'Please complete all the fields';
+
+  $.each(requiredFields, function(i, field) {
+    if (!field.value)
+      isItOk = false;
+  });
+
+  if (isItOk) {
+    $(obj.form).submit();
+  } else {
+    alert(message);
+  }
+}
+
 if (toolBar.length) {
   projectsList.hide(); // Hide project list
 

--- a/app/assets/javascripts/lab/lab.js
+++ b/app/assets/javascripts/lab/lab.js
@@ -1,0 +1,8 @@
+if ($('#hypotheses').length) {
+  $('input[type=text]').on('keydown keyup input propertychange change', function(e) {
+    //mock html5 validation if safari, Ale
+    if (is_safari && e.keyCode === 13 ) {
+      preSubmitForm(this);
+    }
+  });
+}

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -656,21 +656,3 @@ function dynamicInput() {
     });
   })($);
 }
-
-// html5 validation copycat, Ale
-function preSubmitForm(obj) {
-  var requiredFields = $('#'+obj.form.id).find('select, textarea, input').serializeArray();
-      isItOk = true;
-      message = 'Please complete all the fields';
-
-  $.each(requiredFields, function(i, field) {
-    if (!field.value)
-      isItOk = false;
-  });
-
-  if (isItOk) {
-    $(obj.form).submit();
-  } else {
-    alert(message);
-  }
-}

--- a/app/views/hypotheses/_edit.haml
+++ b/app/views/hypotheses/_edit.haml
@@ -3,7 +3,7 @@
     .hypothesis-title.hypothesis-edit{ data: { id: hypothesis.id } }
       %span.bullet
       = form.text_field :description, class: 'hypothesis-title-field',
-      data: { hypothesis_id: hypothesis.id }
+      data: { hypothesis_id: hypothesis.id }, required: true
     .small-12.columns.hypothesis-type-edit{ data: { id: hypothesis.id } }
       = form.select(:hypothesis_type_id,
       hypothesis_types.all.collect { |ht|[ht.description, ht.id] }, { include_blank: t('labs.hypotheses.select_metric')}, { class: 'type edit-type' })


### PR DESCRIPTION
## If I edit and delete the text on a Hypothesis, when saved, the same text appears again. It should show an alert box
#### Trello board reference:
- [Trello Card #281](https://trello.com/c/RROAxqaC)

---
#### Description:
- If I edit and delete the text on a Hypothesis, when saved, the same text appears again. It should show an alert box

---
#### Reviewers:
- @damian @rosina @victoria @bocha

---
#### Notes:
- 

---
#### Tasks:
- [x] Added required to description field
- [x] Fixed copycat for html5 validation on safari

---
#### Risk:
- Medium

---
#### Preview:

![bug281](https://cloud.githubusercontent.com/assets/11840705/11442654/edf5e8ee-94f5-11e5-8253-5587df6f8318.gif)
