### PR TITLE
Fix bug on activities view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'i18n-js'
 gem 'wicked_pdf', github: 'mileszs/wicked_pdf'
 gem 'mustache-js-rails'
 gem 'acts_as_commentable'
+gem 'indefinite_article'
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
     i18n-js (3.0.0.rc11)
       i18n (~> 0.6)
     ice_nine (0.11.1)
+    indefinite_article (0.2.4)
+      activesupport
     ipaddress (0.8.0)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
@@ -434,6 +436,7 @@ DEPENDENCIES
   http-cookie
   httpclient
   i18n-js
+  indefinite_article
   jbuilder (~> 1.2)
   jquery-rails
   jquery-ui-rails (= 5.0.5)

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -35,6 +35,7 @@ function UserStories() {
 
     $('#tag-list').html(html);
     $('.applied-filters').show();
+    fixArticlesForRolesOnBacklog();
   }
 
   function bindRemoveTag() {

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -36,12 +36,12 @@ class UserStory < ActiveRecord::Base
   end
 
   def log_description
-    "#{I18n.t('backlog.user_stories.role')} "\
-      "#{role} "\
-      "#{I18n.t('backlog.user_stories.action', priority: priority)} "\
-      "#{action} "\
-      "#{I18n.t('backlog.user_stories.result')} "\
-      "#{result}"
+    "As #{role.indefinite_article} "\
+    "#{role} "\
+    "#{I18n.t('backlog.user_stories.action', priority: priority)} "\
+    "#{action} "\
+    "#{I18n.t('backlog.user_stories.result')} "\
+    "#{result}"
   end
 
   def recipient

--- a/db/migrate/20151130200611_fix_activities_with_correct_articles.rb
+++ b/db/migrate/20151130200611_fix_activities_with_correct_articles.rb
@@ -1,0 +1,26 @@
+class FixActivitiesWithCorrectArticles < ActiveRecord::Migration
+  def data
+    UserStory.all.each do |user_story|
+      user_story.activities.all.each do |activity|
+        value = activity.value
+        begin
+          if (value.index('I').present?)
+            if (value.index('a/an').present?)
+              subject = value["As a/an ".length..value.index("I")-1]
+              article = subject.indefinite_article
+              activity.value = value.gsub("As a/an #{subject}", "As #{article} #{subject}")
+              activity.save
+            else
+              subject = value["As a ".length..value.index("I")-1]
+              article = subject.indefinite_article
+              activity.value = value.gsub("As a #{subject}", "As #{article} #{subject}")
+              activity.save
+            end
+          end
+        rescue => e
+          logger.warn "Unable to fix article for log line: #{e}"
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151120135914) do
+ActiveRecord::Schema.define(version: 20151130200611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe TagsController, type: :controller do
 
   describe 'GET filter' do
     let!(:tag)           { create :tag, project: project }
-    let!(:another_story) { create :user_story, role: 'admin', project: project }
+    let!(:another_story) { create :user_story, role: 'user', project: project }
     render_views
 
     before :each do
       another_story.tags << tag
     end
 
-    it 'should render the filtered stories' do
+    it 'should render the filtered stories', js: true do
       get(:filter, project_id: project.id, tag_names: [tag.name] )
       expect(response.body).to have_content(another_story.log_description)
       expect(response.body).not_to have_content(user_story.log_description)

--- a/spec/db/migrations/fix_activities_with_correct_articles.rb
+++ b/spec/db/migrations/fix_activities_with_correct_articles.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'migration_data/testing'
+require_migration 'fix_activities_with_correct_articles'
+
+describe FixActivitiesWithCorrectArticles do
+  describe '#data' do
+    it 'works' do
+      expect { described_class.new.data }.to_not raise_exception
+    end
+  end
+end


### PR DESCRIPTION
## BUG - Attach a/an script to new activity page (non-modal)
#### Trello board reference:
- [Trello Card #317](https://trello.com/c/ob4ojr3v)

---
#### Description:
- BUG - Attach a/an script to new activity page (non-modal)

---
#### Reviewers:
- @damian @oscar

---
#### Notes:
- I haven't used the script because those logs are on a db table, so I've manage dot implement a gem for when save the logs; and also created a migration file for (using that gem) fixing the older registries

---
#### Tasks:
- [x] Add gem to put the correct article
- [x] Modify model user story to save the log using correct indefinite article
- [x] Provide a migration file to fix older data
- [x] Provide syntax's test on migration file

---
#### Risk:
- Medium

---
#### Preview:
- N/A
