### PR TITLE
Fix/archive feture add it to backlog

### DIFF
--- a/.reek
+++ b/.reek
@@ -30,7 +30,8 @@ FeatureEnvy:
     TrelloServices#config,
     ProjectServices#activities_by_pages,
     LinkAttachmentServices#fetch_http_content_type,
-    FileUploader#extract_type
+    FileUploader#extract_type,
+    UserStoriesController#story_update_params
   ]
 IrresponsibleModule:
   enabled: false

--- a/app/assets/javascripts/userStories/userStories.js
+++ b/app/assets/javascripts/userStories/userStories.js
@@ -142,6 +142,7 @@ function UserStories() {
       refreshStories();
       bindAcceptanceCriterionFadeOut();
       bindConstraintFadeOut();
+      bindArchiveLink();
     });
   }
 
@@ -424,6 +425,19 @@ function UserStories() {
     });
   }
 
+  function bindArchiveLink() {
+    $('.archive-link').click(function() {
+      var userStory = {
+            user_story: { archived: true }
+          }
+          url = $(this).data('url'),
+          type  = 'put';
+
+      editFormAjax(url, type, userStory);
+      return false;
+    });
+  }
+
   function bindEditConstraint() {
     $editConstraintForm = $('.edit_constraint');
 
@@ -450,7 +464,7 @@ function UserStories() {
   }
 
   function refreshStories() {
-    $('.user-story-edit-form .user-story-input input:text').each(function() {
+    $('.user-story-edit-form .user-story-input input.role:text').each(function() {
       var $this  = $(this),
           $span  = $this.parent().find('span'),
           $value = $this.val;

--- a/app/assets/stylesheets/_archives.scss
+++ b/app/assets/stylesheets/_archives.scss
@@ -20,7 +20,7 @@
 }
 
 .restore-link,
-.user-story-input.archive {
+.archive-link {
   font-size: rem-calc(10);
   font-weight: $font-weight-bold;
   text-transform: uppercase;
@@ -31,3 +31,10 @@
     width: rem-calc(13);
   } // checkbox archive
 } // user story archived
+
+.archive-link {
+  opacity: 0;
+  text-align: right;
+  
+  &:hover { opacity: 1; }
+}

--- a/app/controllers/user_stories_controller.rb
+++ b/app/controllers/user_stories_controller.rb
@@ -77,6 +77,7 @@ class UserStoriesController < ApplicationController
   def story_update_params
     params = user_story_params
     params[:tag_ids] ||= []
+    params[:archived]
     params
   end
 
@@ -152,7 +153,7 @@ class UserStoriesController < ApplicationController
   def user_story_params
     params.require(:user_story).permit(
       :role, :action, :result, :estimated_points,
-      :priority, :archived, :hypothesis_id, tag_ids: []
+      :priority, :archived, :hypothesis_id, :archived, tag_ids: []
     )
   end
 

--- a/app/views/user_stories/_backlog_list.haml
+++ b/app/views/user_stories/_backlog_list.haml
@@ -34,3 +34,4 @@
           %span=user_story.action
           %span.grey-prefix= t('backlog.user_stories.result')
           %span=user_story.result
+        = link_to t('archive.link'), '#', class: 'archive-link', data: { url: user_story_path(user_story)}

--- a/app/views/user_stories/_form.haml
+++ b/app/views/user_stories/_form.haml
@@ -22,6 +22,7 @@
         class:       'role',                               |
         'data-autosize-input' => '{ "space": 10 }',        |
       )                                                    |
+
     .user-story-input.action
       = t('backlog.user_stories.action_prefix')
       .user-story-priority
@@ -36,6 +37,7 @@
         class:      'action',                                |
         'data-autosize-input' => '{ "space": 10 }'           |
       )                                                      |
+
     .user-story-input.result
       = t('backlog.user_stories.result')
       %span.show-result{ title: t('backlog.user_stories.edit_result') }

--- a/app/views/user_stories/_lab_form.haml
+++ b/app/views/user_stories/_lab_form.haml
@@ -40,10 +40,7 @@ url: form_url do |form|
       class:      'result',                                |
       'data-autosize-input' => '{ "space": 10 }'           |
     )                                                      |
-  .user-story-input.archive
-    = form.check_box(:archived)
-    = t('archive.link')
-  .enter - press &#8629; to finish
+
   - if hypothesis
     = form.hidden_field :hypothesis_id, value: hypothesis.id
   = form.submit I18n.translate('save'), class: 'hide user-story-submit'


### PR DESCRIPTION
## As a Collaborator, I should be able to archive a user story, so that I can restore the user story to the backlog if needed in the future
#### Trello board reference:
- [Trello Card #244](https://trello.com/c/zRecTCyJ)

---
#### Description:
- As a Collaborator, I should be able to archive a user story, so that I can restore the user story to the backlog if needed in the future

---
#### Reviewers:
- @oscar @pgonzaga @damian @rosina

---
#### Notes:
- 

---
#### Tasks:
- [x] Added archived to permitted params
- [x] Added a js function to manage click on archive link using ajax (update user story setting archived=true)
- [x] Added basic styles

---
#### Risk:
- High

---
#### Preview:

![archive](https://cloud.githubusercontent.com/assets/11840705/11518600/b6627116-9871-11e5-98fe-e9bf13b7be0f.gif)
