### PR TITLE
Add member preview on navigation.

### DIFF
--- a/app/assets/images/icons/po_avatar.svg
+++ b/app/assets/images/icons/po_avatar.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="-693 663.3 32 32" style="enable-background:new -693 663.3 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#BCBEC0;}
+	.st1{font-family:'MyriadPro-Regular';}
+	.st2{font-size:5.9257px;}
+</style>
+<g>
+	<path class="st0" d="M-677,683.8c-3.6,0-6.5-2.9-6.5-6.5s2.9-6.5,6.5-6.5s6.5,2.9,6.5,6.5S-673.4,683.8-677,683.8z M-677,674.8
+		c-1.4,0-2.5,1.1-2.5,2.5s1.1,2.5,2.5,2.5s2.5-1.1,2.5-2.5S-675.6,674.8-677,674.8z"/>
+</g>
+<g>
+	<path class="st0" d="M-668.5,690.3c-1.1,0-2-0.9-2-2c0-1.7-1.3-3-3-3h-7c-1.7,0-3,1.3-3,3c0,1.1-0.9,2-2,2s-2-0.9-2-2
+		c0-3.9,3.1-7,7-7h7c3.9,0,7,3.1,7,7C-666.5,689.4-667.4,690.3-668.5,690.3z"/>
+</g>
+<g>
+	<path class="st0" d="M-677,695.3c-8.8,0-16-7.2-16-16s7.2-16,16-16s16,7.2,16,16S-668.2,695.3-677,695.3z M-677,667.3
+		c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S-670.4,667.3-677,667.3z"/>
+</g>
+<text transform="matrix(1 0 0 1 -680.3331 690.0073)" class="st0 st1 st2">PO</text>
+</svg>

--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -159,9 +159,8 @@
 
       @media #{$small-only} { display: none; }
 
-      &.add-member {
-        @include border-radius(100%);
-        @include inline-block;
+      &.add-member,
+      &.other-members {
         background-color: $black-20;
         color: $secondary-nav-color;
         font-size: rem-calc(14);
@@ -173,6 +172,20 @@
         width: rem-calc(20);
 
         @media #{$small-only} { display: inline-block; }
+      }
+
+      &.other-members {
+        background-color: transparent;
+        border: 1px solid $black-30;
+        color: $black-20;
+        font-size: rem-calc(12);
+        height: rem-calc(30);
+        letter-spacing: 0;
+        line-height: rem-calc(29);
+        margin-right: rem-calc(10);
+        width: rem-calc(30);
+
+        @media #{$small-only} { display: none; }
       }
     }
 

--- a/app/views/layouts/_navigation.haml
+++ b/app/views/layouts/_navigation.haml
@@ -70,15 +70,24 @@
                 = t('project.delete_project')
                 %span.icon-trash
       %ul.right.members
-        %li
-          = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('test-user.png') });"} do
-            = image_tag ('icons/user-icon.svg'), class: 'hide'
-        %li
-          = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('test-user.png') });"} do
-            = image_tag ('icons/user-icon.svg'), class: 'hide'
-        %li
-          = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('test-user.png') });"} do
-            = image_tag ('icons/user-icon.svg'), class: 'hide'
+        - current_project.members.each_with_index do |member, index|
+          - if index == 0
+            %li
+              = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('icons/po_avatar.svg') });"} do
+                = image_tag ('icons/user-icon.svg'), class: 'hide'
+          - if index == 1
+            %li
+              = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('icons/user-icon.svg') });"} do
+                = image_tag ('icons/user-icon.svg'), class: 'hide'
+          - if index == 2
+            %li
+              = link_to arbor_reloaded_project_path(current_project), { style: "background-image: url(#{ image_path('icons/user-icon.svg') });"} do
+                = image_tag ('icons/user-icon.svg'), class: 'hide'
+        - if current_project.members.count > 3
+          %li
+            = link_to arbor_reloaded_project_path(current_project), class: 'other-members' do
+              +
+              = current_project.members.count - 3
         %li
           = link_to arbor_reloaded_project_path(current_project), class: 'add-member' do
             +


### PR DESCRIPTION
## As a user I should be able to see a preview of project members on a projects tab bar navigation so that I can quickly see who is collaborating
#### Trello board reference:
- [Trello Card #22](https://trello.com/c/rf4j3tsW/334-22-3-as-a-user-i-should-be-able-to-see-a-preview-of-project-members-on-a-projects-tab-bar-navigation-so-that-i-can-quickly-see-w)

---
#### Description:
- Add a preview of the project members

---
#### Reviewers:
- @AlejandroFernandesAntunes @rosinanabazas

---
#### Notes:
- 

---
#### Tasks:
- [x] Add the logic to display members
- [x] Ensure first member is owner
- [x] Add counter with the amount of members
- [x] Add the styles

---
#### Risk:
- Low

---
#### Preview:

<img width="1398" alt="screen shot 2015-12-02 at 16 26 34" src="https://cloud.githubusercontent.com/assets/6106206/11541541/8b1b884e-9911-11e5-9122-68ad6e3b7aca.png">
