### PR TITLE
Correct Archive's link hover opacity

### DIFF
--- a/app/assets/stylesheets/_archives.scss
+++ b/app/assets/stylesheets/_archives.scss
@@ -35,6 +35,4 @@
 .archive-link {
   opacity: 0;
   text-align: right;
-  
-  &:hover { opacity: 1; }
 }

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -36,7 +36,8 @@
       &:active   { @include grabbing-cursor; }
       &.selected { background-color: rgba($black, .05); }
 
-      &:hover .hover-options { @include opacity(1); }
+      &:hover .hover-options,
+      &:hover .archive-link { @include opacity(1); }
 
       .number,
       .points {


### PR DESCRIPTION
## Fix Archive link's hover
#### Trello board reference:
- [Trello Card #244](https://trello.com/c/zRecTCyJ/244-244-3-as-a-collaborator-i-should-be-able-to-archive-a-user-story-so-that-i-can-restore-the-user-story-to-the-backlog-if-needed-i)

---
#### Description:
- Now the Archive link appears when the user hovers on the entire user story

---
#### Reviewers:
- @ale

---
#### Tasks:
- [x] Move hover state to user story instead of archive-link

---
#### Risk:
- Low

---
#### Preview:

<img width="441" alt="screen shot 2015-12-02 at 5 37 49 p m" src="https://cloud.githubusercontent.com/assets/6147409/11543442/72648454-991b-11e5-88cc-de155f96fc57.png">
