### PR TITLE
Reorder the preview members on nav bar.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -166,12 +166,15 @@
         font-size: rem-calc(14);
         height: rem-calc(20);
         line-height: rem-calc(19);
-        margin-right: 0;
+        margin-right: rem-calc(10);
         text-align: center;
         vertical-align: middle;
         width: rem-calc(20);
 
-        @media #{$small-only} { display: inline-block; }
+        @media #{$small-only} {
+          display: inline-block;
+          margin-right: 0;
+        }
       }
 
       &.other-members {
@@ -182,7 +185,7 @@
         height: rem-calc(30);
         letter-spacing: 0;
         line-height: rem-calc(29);
-        margin-right: rem-calc(10);
+        margin-right: 0;
         width: rem-calc(30);
 
         @media #{$small-only} { display: none; }

--- a/app/views/layouts/_navigation.haml
+++ b/app/views/layouts/_navigation.haml
@@ -72,6 +72,9 @@
                 = t('project.delete_project')
                 %span.icon-trash
       %ul.right.members
+        %li
+          = link_to arbor_reloaded_project_path(current_project), class: 'add-member' do
+            +
         - current_project.members.each_with_index do |member, index|
           - if index == 0
             %li
@@ -90,7 +93,4 @@
             = link_to arbor_reloaded_project_path(current_project), class: 'other-members' do
               +
               = current_project.members.count - 3
-        %li
-          = link_to arbor_reloaded_project_path(current_project), class: 'add-member' do
-            +
   #project-members-modal.reveal-modal{ data: { reveal: '' } }


### PR DESCRIPTION
## As a user I should be able to see a preview of project members on a projects tab bar navigation so that I can quickly see who is collaborating
#### Trello board reference:
- [Trello Card #22](https://trello.com/c/rf4j3tsW/334-22-3-as-a-user-i-should-be-able-to-see-a-preview-of-project-members-on-a-projects-tab-bar-navigation-so-that-i-can-quickly-see-w)

---
#### Description:
- Reorder the icons on members preview

---
#### Reviewers:
- @rosina

---
#### Notes:
- 

---
#### Tasks:
- [x] Move the plus icon from last place to first one

---
#### Risk:
- Low

---
#### Preview:

<img width="494" alt="screen shot 2015-12-04 at 17 08 25" src="https://cloud.githubusercontent.com/assets/6106206/11600163/aaaf81f8-9aa9-11e5-8e6d-b1159be81088.png">
