### PR TITLE
Epic production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,11 +5,14 @@ Railsroot::Application.configure do
   config.action_controller.perform_caching = true
   config.serve_static_files = false
   config.assets.js_compressor = :uglifier
-  config.assets.compile = false
-  config.assets.version = '1.0'
+  config.assets.compile = true
+  config.assets.version = '1.4'
   config.assets.digest = true
   config.log_level = :info
-  config.assets.precompile += %w( vendor/modernizr.js )
+  config.assets.precompile += %w(
+    vendor/modernizr.js
+    stylesheets/application_pdf.css.scss
+  )
   config.action_mailer.default_url_options = { host: ENV['DEFAULT_HOST'] }
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify


### PR DESCRIPTION
## New stylesheets compilation
#### Trello board reference:
- [Trello Card #QUICK FIX]()

---
#### Description:
- We were having problems when we introduce a new file, it was some kind of bug. The solution here is telling Heroku to compile the new assets with:
  config.assets.compile = true 
  and a new version for:
  config.assets.version = '1.4' 
  Also every new file invoked from a controller (to render a new layout) or the actual application layout file MUST be included in the assets precompile array as it follows: 
  config.assets.precompile += %w(
    vendor/modernizr.js
    stylesheets/application_pdf.css.scss
  )

---
#### Reviewers:
- @vico @oscarsiniscalchi @pgonzaga

---
#### Notes:
- 

---
#### Tasks:
- [x] Modify configurations for production environment

---
#### Risk:
- High

---
