### PR TITLE
Add dependency of comments on user_story destroy

### DIFF
--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -16,7 +16,7 @@ class UserStory < ActiveRecord::Base
   has_and_belongs_to_many :tags
   has_many :acceptance_criterions,
     -> { order(order: :asc) }, dependent: :destroy
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_many :constraints,
     -> { order(order: :asc) }, dependent: :destroy
   belongs_to :hypothesis


### PR DESCRIPTION
## Add dependency of comments on user_story destroy
#### Trello board reference:
- [Trello Card #407](https://trello.com/c/eZ6gJFtK/407-407-backend-bug-add-destroy-dependency-on-comments-with-user-stories)

---
#### Description:
- Any comments related to a story should be deleted when the story is deleted.

---
#### Risk:
- Low

---
