### PR TITLE
Fix redirect to new canvas.

### DIFF
--- a/app/controllers/arbor_reloaded/projects_controller.rb
+++ b/app/controllers/arbor_reloaded/projects_controller.rb
@@ -126,7 +126,7 @@ module ArborReloaded
       if @project.save
         @project.create_activity :create_project
         assign_associations
-        redirect_to project_canvases_path(@project)
+        redirect_to arbor_reloaded_project_canvases_path(@project)
       else
         @errors = @project.errors.full_messages
         render :new, status: 400


### PR DESCRIPTION
Quick fix on staging of redirection bug introduced on rebase. 
On project create, redirects to arbor reloaded canvas.
Now I merge it to master so it's updated.
