### PR TITLE
Remove people link from navigation.

### DIFF
--- a/app/views/layouts/_navigation.haml
+++ b/app/views/layouts/_navigation.haml
@@ -18,11 +18,6 @@
       %ul.sections
         %li
           = link_to t('reloaded.navigation.projects'), arbor_reloaded_root_path
-        - if current_project
-          %li
-            = link_to t('reloaded.navigation.people'), |
-            arbor_reloaded_project_members_path(current_project), |
-            { data: { reveal_id: 'project-members-modal', reveal_ajax: true } }
         %li
           %a{:href => 'mailto:feedback@getarbor.io', :target => '_top'}= t('reloaded.navigation.help')
         %li.hide

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,7 +194,6 @@ en:
     navigation:
       menu: 'Menu'
       projects: 'Projects'
-      people: 'People'
       welcome: 'Welcome,'
       settings: 'Settings'
       canvas: 'Canvas'


### PR DESCRIPTION
## Delete "People" link on the top bar and just leave the plus icon for adding members
#### Trello board reference:
- [Trello Card #408](https://trello.com/c/AM8zh7j0/408-1-feedback-delete-people-link-on-the-top-bar-and-just-leave-the-plus-icon-for-adding-members)

---
#### Description:
- 

---
#### Reviewers:
- @rosinanabazas @AlejandroFernandesAntunes 

---
#### Notes:
- 

---
#### Tasks:
- [x] Remove people link from main navigation

---
#### Risk:
- Low

---
