### PR TITLE
We use scss-linter in atom and this runs with scss_lint gem as the other projects, not scss-lint.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   gem 'reek'
   gem 'rails_best_practices'
   gem 'rubocop'
-  gem 'scss-lint'
+  gem 'scss_lint', require: false
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'wkhtmltopdf-binary-edge', '~> 0.12.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,9 +353,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
+    scss_lint (0.43.2)
       rainbow (~> 2.0)
-      sass (~> 3.4.1)
+      sass (~> 3.4.15)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -460,7 +460,7 @@ DEPENDENCIES
   rubocop
   ruby-trello!
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   sdoc
   shoulda-matchers
   spork-rails

--- a/app/assets/stylesheets/_attachments.scss
+++ b/app/assets/stylesheets/_attachments.scss
@@ -107,7 +107,7 @@
         font-weight: $font-weight-bold;
         margin-top: rem-calc(5);
 
-        &:after {
+        &::after {
           color: $black-40;
           content: '\2022';
           font-size: rem-calc(15);

--- a/app/assets/stylesheets/_backlog.scss
+++ b/app/assets/stylesheets/_backlog.scss
@@ -55,7 +55,7 @@
     .number {
       display: inline-block;
 
-      &:after {
+      &::after {
         color: $black-40;
         content: '\2022';
         font-size: rem-calc(15);
@@ -379,7 +379,7 @@
         @include inline-block;
         font-weight: $font-weight-bold;
 
-        &:after {
+        &::after {
           color: $lab-color;
           content: '\2022';
           font-size: rem-calc(13);
@@ -482,7 +482,7 @@
   min-width: rem-calc(100);
   vertical-align: top;
 
-  &:after {
+  &::after {
     @include transition(color .25s ease-in, opacity .25s ease-in);
     color: $font-color-3;
     content: '⇧+click to delete';
@@ -492,7 +492,7 @@
     opacity: 0;
   }
 
-  &:hover:after { opacity: 1; }
+  &:hover::after { opacity: 1; }
 }
 
 .story-tags span {
@@ -550,7 +550,7 @@
   margin-left: rem-calc(5);
   text-transform: uppercase;
 
-  &:before {
+  &::before {
     @include border-radius(rem-calc(100));
     background-color: $black-30;
     color: $white;

--- a/app/assets/stylesheets/_pdf_export.scss
+++ b/app/assets/stylesheets/_pdf_export.scss
@@ -79,7 +79,7 @@
     .number {
       display: inline-block;
 
-      &:after {
+      &::after {
         color: $black-40;
         content: '\2022';
         font-size: rem-calc(15);

--- a/app/assets/stylesheets/arbor_reloaded/_icons.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_icons.scss
@@ -28,16 +28,16 @@
   vertical-align: middle;
 }
 
-.icn-favorite-empty:before { content: '\e904'; }
-.icn-favorite:before { content: '\e906'; }
-.icn-delete:before { content: '\e907'; }
-.icn-copy:before { content: '\e908'; }
-.icn-archive:before { content: '\e900'; }
-.icn-arrow-dropdown:before { content: '\e901'; }
-.icn-arrow:before { content: '\e902'; }
-.icn-comments:before { content: '\e903'; }
-.icn-cross:before { content: '\e905'; }
-.icn-notifications:before { content: '\e909'; }
-.icn-search:before { content: '\e90a'; }
-.icn-settings:before { content: '\e90b'; }
-.icn-signout:before { content: '\e90c'; }
+.icn-favorite-empty::before { content: '\e904'; }
+.icn-favorite::before { content: '\e906'; }
+.icn-delete::before { content: '\e907'; }
+.icn-copy::before { content: '\e908'; }
+.icn-archive::before { content: '\e900'; }
+.icn-arrow-dropdown::before { content: '\e901'; }
+.icn-arrow::before { content: '\e902'; }
+.icn-comments::before { content: '\e903'; }
+.icn-cross::before { content: '\e905'; }
+.icn-notifications::before { content: '\e909'; }
+.icn-search::before { content: '\e90a'; }
+.icn-settings::before { content: '\e90b'; }
+.icn-signout::before { content: '\e90c'; }

--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -36,7 +36,7 @@ li { list-style: none; }
   position: relative;
   width: rem-calc(20);
 
-  &:after {
+  &::after {
     @include transition(opacity .25s ease-in-out, color .25s ease-in-out);
     @include transform(rotate(45deg) translate(-50%, -50%));
     @include opacity(0);
@@ -50,12 +50,12 @@ li { list-style: none; }
     top: 50%;
   }
 
-  &:hover:after { @include opacity(1); }
+  &:hover::after { @include opacity(1); }
 
   &:checked {
-    &:hover:after { color: $black-50; }
+    &:hover::after { color: $black-50; }
 
-    &:after {
+    &::after {
       @include opacity(1);
       color: $black-70;
     }

--- a/app/assets/stylesheets/arbor_reloaded/_navigation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_navigation.scss
@@ -45,7 +45,7 @@ $avatar-dimension: rem-calc(40);
   .has-notification {
     position: relative;
 
-    &:before {
+    &::before {
       color: $backlog-color;
       content: '•';
       font-size: rem-calc(28);
@@ -137,7 +137,7 @@ ul .f-dropdown {
       position: relative;
 
       &:hover { color: $white; }
-      &::last-child { margin-right: 0; }
+      &:last-child { margin-right: 0; }
     }//secondary nav specific first lvl selection
   }// ul li
 

--- a/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
@@ -219,7 +219,7 @@
     &:hover {
       @include opacity(.7);
 
-      &:before { content: '\e906'; }}
+      &::before { content: '\e906'; }}
   }//icon
 
   .breaker {


### PR DESCRIPTION
[#356] We use scss-linter in atom and this runs with scss_lint gem as the other projects, not scss-lint.

/cc @rosinanabazas @AlejandroFernandesAntunes 
## References
- Performance task
## Risks

**Low.** 
