### PR TITLE
Hide default search text result

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -47,6 +47,8 @@ li { list-style: none; }
   }
 } // circle
 
+.ui-helper-hidden-accessible { display: none; } // hide default search result text coming from the jquery widget
+
 // -------  BASE FORM STYLES ------ //
 
 input:focus {


### PR DESCRIPTION
## Fix project search bar bug
#### Trello board reference:
- [Trello Card #443](https://trello.com/c/kHsrJdXF/443-443-2-project-search-bug-getting-some-text-appear-at-the-bottom-of-the-browser-when-searching)

---
#### Description:
- The result was getting some default search result from the ui jquery widget

---
#### Reviewers:
- @mojo

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-01-05 at 5 32 40 p m](https://cloud.githubusercontent.com/assets/6147409/12126827/5c0de2b4-b3d2-11e5-9f8d-5b02ccf4e6c0.png)
