### PR TITLE
Remove js call to hide inputs causing a delay, better call it by css

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_members.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_members.js
@@ -10,7 +10,6 @@ $('#project-members-modal').on('opened.fndtn.reveal', function() {
       removeMemberFromProjectLink = $('.remove-member-link a'),
       footerButtonInitialText = $(footerButtonId).text();
 
-  hideSpecifiedElements();
   bindActionsToButton();
   bindActionsOnRemovalCheckboxes();
   displayInitialWhenNoAvatar();
@@ -25,12 +24,6 @@ $('#project-members-modal').on('opened.fndtn.reveal', function() {
    }
  });
 });
-
-function hideSpecifiedElements() {
-  $('.hidden-input-element').each(function(index, currentValue) {
-    $(currentValue).hide();
-  });
-}
 
 //button function depending on what it says, Ale
 function bindActionsToButton() {

--- a/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
+++ b/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
@@ -88,3 +88,5 @@ $headers-font-color: #393939;
   overflow: hidden;
   white-space: nowrap;
 }
+
+.hidden-input-element { display: none !important; }


### PR DESCRIPTION
**[ Enhancement ]**

We where getting a jump when loading modal members cause we were hiding the elements via JS.

https://trello.com/c/8OwuVq9W

cc: @AlejandroFernandesAntunes  @rosinanabazas @doshii 
