### PR TITLE
Add deletion to user story modal.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -63,7 +63,6 @@ function toggleModalStoryDropdown() {
     if ($trigger.hasClass('open')) {
       $trigger.removeClass('open');
       $actions.removeClass('active');
-      return false;
     }
   });
 }//toggle actions dropwdon on modal
@@ -83,7 +82,6 @@ function toggleDeleteConfirmation() {
     if ($confirmationWarning.hasClass('active')) {
       $confirmationWarning.removeClass('active');
       $headerWrapper.removeClass('inactive');
-      return false;
     }
   });
 }//show delete confirmation

--- a/app/controllers/arbor_reloaded/user_stories_controller.rb
+++ b/app/controllers/arbor_reloaded/user_stories_controller.rb
@@ -1,7 +1,7 @@
 module ArborReloaded
   class UserStoriesController < ApplicationController
     layout 'application_reload'
-    before_action :load_user_story, only: [:edit, :show, :update]
+    before_action :load_user_story, only: [:edit, :show, :update, :destroy]
     before_action :check_edit_permission, only: [:create, :index]
     before_action :copied_user_stories, only: :copy
 
@@ -40,6 +40,11 @@ module ArborReloaded
       user_story_service = ArborReloaded::UserStoryService.new(@project)
       user_story_service.copy_stories(@copied_stories)
       render json: { project_url: project_user_stories_path(@project) }
+    end
+
+    def destroy
+      @user_story.destroy
+      redirect_to :back
     end
 
     private

--- a/app/views/arbor_reloaded/user_stories/show.haml
+++ b/app/views/arbor_reloaded/user_stories/show.haml
@@ -32,7 +32,7 @@
       %span.author Napoleon Martinez
   .delete-confirmation-overlay
     %p.title= t('reloaded.story_modal.delete.confirmation_text')
-    = link_to t('reloaded.project_dashboard.delete_project'), '#', method: :delete, class: 'button radius alert tiny'
+    = link_to t('reloaded.project_dashboard.delete_project'), arbor_reloaded_user_story_path(@user_story), method: :delete, class: 'button radius alert tiny'
     = link_to t('reloaded.project_dashboard.cancel'), '#', class: 'cancel'
     %p.disclaimer= t('reloaded.story_modal.delete.disclaimer')
   .edition-form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,7 @@ Railsroot::Application.routes.draw do
           as: :reorder_backlog
 
       resources :backlog,
-          only: [:create, :index, :show, :update],
+          only: [:create, :index, :show, :update, :destroy],
           as: :user_stories,
           controller: :user_stories do
         resources :acceptance_criterions, only: [:create]


### PR DESCRIPTION
## As a User I should be able to delete the user-story from the user-story-modal.
#### Trello board reference:
- [Trello Card #447](https://trello.com/c/SMhuJQjT/447-447-3-as-a-user-i-should-be-able-to-delete-the-user-story-from-the-user-story-modal)

---
#### Description:
- 

---
#### Reviewers:
- @vicocas @AlejandroFernandesAntunes 

---
#### Notes:
- @mojouy  I had to remove the return false calls from the js because they prevent the delete action to be submitted

---
#### Tasks:
- [x] Add delete method in controller
- [x] Add route
- [x] Point link

---
#### Risk:
- Medium

---
