### PR TITLE
Stop page from reload, reload content by js.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -127,9 +127,6 @@ $(document).ready(function() {
   $('#story-detail-modal').foundation('reveal', {
     opened: function () {
       displayEditionForm();
-    },
-    closed: function () {
-      location.reload();
     }
   });
 

--- a/app/views/arbor_reloaded/user_stories/_user_stories_list.haml
+++ b/app/views/arbor_reloaded/user_stories/_user_stories_list.haml
@@ -1,0 +1,4 @@
+- if project.user_stories.count > 0
+  - project.user_stories.each do |user_story|
+    = render 'arbor_reloaded/user_stories/user_story', user_story: user_story
+    = render 'arbor_reloaded/user_stories/story_detail_modal', user_story: user_story

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -5,9 +5,7 @@
     = link_to '', '#', class: 'icn-copy', data: { reveal_id: 'copy-stories-modal'}
     = link_to '', '#', class: 'icn-archive'
     = link_to '', '#', class: 'icn-delete story-delete-link', data: { reveal_id: 'story-delete-modal'}
-  - if @project.user_stories.count > 0
-    - @project.user_stories.each do |user_story|
-      = render 'arbor_reloaded/user_stories/user_story', user_story: user_story
-      = render 'arbor_reloaded/user_stories/story_detail_modal', user_story: user_story
+  .user-stories-container
+    = render 'arbor_reloaded/user_stories/user_stories_list', project: @project
 = render 'arbor_reloaded/user_stories/story_delete_modal'
 = render 'arbor_reloaded/user_stories/copy_stories_modal'

--- a/app/views/arbor_reloaded/user_stories/update.js.erb
+++ b/app/views/arbor_reloaded/user_stories/update.js.erb
@@ -1,3 +1,5 @@
 $('span#role').html('<%= j @user_story.role%>');
 $('span#action').html('<%= j @user_story.action%>');
 $('span#result').html('<%= j @user_story.result%>');
+$('.user-stories-container').html('');
+$('.user-stories-container').html("<%= j render 'arbor_reloaded/user_stories/user_stories_list', project: @user_story.project.reload %>");


### PR DESCRIPTION
# [enhancement] Prevent reload on user story page after closing user story modal
#### Trello board reference:
- [Trello Card #458](https://trello.com/c/87HvFoM8/458-458-enhancement-prevent-reload-on-user-story-page-after-closing-user-story-modal)

---
#### Description:
- Stop the page from reload, make the content auto populate from JS

---
#### Reviewers:
- @AlejandroFernandesAntunes  @vicocas 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
