### PR TITLE
Add min-height to modal's header wrapper

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
@@ -12,6 +12,7 @@
 
   header {
     .header-wrapper {
+      min-height: rem-calc(135);
       padding: $modal-padding;
 
       &.inactive { display: none; }


### PR DESCRIPTION
## Add min-height to modal's header
#### Trello board reference:
- [Trello Card #450](https://trello.com/c/wzaPvKHa/450-450-1-feedback-find-a-design-solution-for-overlapping-icon-on-user-story-modal)

---
#### Description:
- Fixes overlapped icon on modal's header

---
#### Reviewers:
- @mojouy 

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-01-11 at 2 51 28 p m](https://cloud.githubusercontent.com/assets/6147409/12241729/83dc906a-b873-11e5-8d03-a12a881e39fd.png)
