### PR TITLE
Separate old and reloaded font kits

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -6,7 +6,7 @@
   background-color: $dashboard-hover-color;
   color: $black-40;
   font-size: rem-calc(22);
-  margin: rem-calc(50) auto rem-calc(30);
+  margin: rem-calc(50) auto 0;
   padding: rem-calc(15 25);
 
   .backlog-story-input {

--- a/app/views/layouts/application_reload.html.haml
+++ b/app/views/layouts/application_reload.html.haml
@@ -22,7 +22,7 @@
     = stylesheet_link_tag 'application_reload'
     = javascript_include_tag 'vendor/modernizr'
     = csrf_meta_tags
-    = javascript_include_tag '//use.typekit.net/uyn6gfv.js'
+    = javascript_include_tag '//use.typekit.net/iac3ber.js'
     :javascript
       try{Typekit.load();}catch(e){}
   %body{'data-action' => action_name, 'data-controller' => controller_name }


### PR DESCRIPTION
## Separate Typekit's fonts from Old and New Arbor
#### Trello board reference:
- [Trello Card #468](https://trello.com/c/3DrB8TQ2/468-separate-old-and-new-arbor-s-fonts-on-typekit)

---
#### Reviewers:
- @mojo

---
#### Risk:
- Low
