### PR TITLE
remove copy icon from user story modal

### DIFF
--- a/app/views/arbor_reloaded/user_stories/show.haml
+++ b/app/views/arbor_reloaded/user_stories/show.haml
@@ -4,7 +4,6 @@
     .story-actions
       = link_to '···', '#', class: 'story-actions-link'
       = link_to '', '#', class: 'icn-delete'
-      = link_to '', '#', method: :post, class: 'icn-copy'
       = link_to '', '#', method: :post, class: 'icn-archive'
     %h4
       %span.story-points{ data: { id: @user_story.id } }= @user_story.estimated_points ||= '?'

--- a/spec/features/arbor_reloaded/user_story/story_detail_spec.rb
+++ b/spec/features/arbor_reloaded/user_story/story_detail_spec.rb
@@ -37,7 +37,6 @@ feature 'Story detail modal', js:true do
     find('.story-actions').click
     within '#story-detail-modal' do
       expect(page).to have_css('a.icn-delete')
-      expect(page).to have_css('a.icn-copy')
       expect(page).to have_css('a.icn-archive')
     end
   end


### PR DESCRIPTION
## Remove the copy link from the user story modal
#### Trello board reference:
- [Trello Card #463](https://trello.com/c/nRlT5OHz/463-2-copy-link-in-user-story-modal-throws-an-error)

---
#### Description:
- The PO decided it won't be there anymore

---
#### Risk:
- Low

---
