### PR TITLE
Delete comments on User Story modal

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
@@ -185,6 +185,7 @@
       margin-bottom: $story-section-margin;
 
       &:last-child { margin-bottom: 0; }
+      &:hover { .icn-delete { display: block; } }
     } // li
 
     .author {
@@ -193,7 +194,20 @@
     } // author
 
     .date { font-size: rem-calc(10); }
-    .comment { display: block; }
+
+    .comment {
+      cursor: default;
+      display: block;
+    } // comment
+
+    .icn-delete {
+      display: none;
+      float: right;
+      font-size: rem-calc(14);
+      margin-right: rem-calc(10);
+
+      &:hover { @include opacity(.8); }
+    } // icn delete
   } // comment list
 
   .modal-footer { height: rem-calc(40); }

--- a/app/views/arbor_reloaded/comments/_comment.haml
+++ b/app/views/arbor_reloaded/comments/_comment.haml
@@ -1,4 +1,5 @@
 %li
   %span.author= comment.user_name
   %span.date= comment.created_at.to_s
+  = link_to '', '#', class: 'icn-delete'
   %span.comment= comment.comment

--- a/app/views/arbor_reloaded/comments/_form.haml
+++ b/app/views/arbor_reloaded/comments/_form.haml
@@ -1,4 +1,4 @@
 = form_for(comment, remote: true) do |form|
-  = form.text_area :comment, class: 'backlog-placeholder resizable-text-area',
+  = form.text_area :comment, class: 'backlog-placeholder resizable-text-area radius',
   placeholder: t('backlog.user_stories.new_comment')
   = form.submit t('save'), id: 'save-comment', class: 'hide'

--- a/spec/features/arbor_reloaded/user_story/delete_comment_spec.rb
+++ b/spec/features/arbor_reloaded/user_story/delete_comment_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+feature 'Delete comment on User Story modal' do
+  let!(:user)         { create :user }
+  let!(:project)      { create :project, owner: user }
+  let!(:user_story)   { create :user_story, project: project }
+
+  background do
+    sign_in user
+    visit arbor_reloaded_project_user_stories_path(project)
+  end
+
+  scenario 'Should be able to click on a user story and see a modal', js: true do
+    find(".story-detail-link").click
+    expect(page).to have_css('#story-detail-modal')
+  end
+
+  scenario 'Should be able to see the comment form', js: true do
+    find(".story-detail-link").click
+    expect(page).to have_css('#comment_comment')
+  end
+
+  context 'When there are comments' do
+    let!(:comment) { create :comment, comment: 'This is a comment', user_story: user_story }
+
+    scenario 'Should be able to see the comment' do
+      find(".story-detail-link").click
+      expect(page).to have_content('This is a comment')
+    end
+
+    scenario 'Should be able to see the delete comment icon' do
+      find(".story-detail-link").click
+      expect(page).to have_css('.icn-delete')
+    end
+  end
+end


### PR DESCRIPTION
## Delete comments on User Story modal
#### Trello board reference:
- [Trello Card #82](https://trello.com/c/PYET04mA/400-82-2-as-a-user-i-should-be-able-to-delete-my-own-comment-so-that-if-i-mess-up-i-can-get-rid-of-it)

---
#### Description:
- As a user I should be able to delete my own comment so that if I mess up, I can get rid of it

---
#### Reviewers:
- @doshi

---
#### Notes:
- Functionality​ will be added by backend

---
#### Preview:

![screen shot 2016-01-14 at 12 06 25 p m](https://cloud.githubusercontent.com/assets/6147409/12327841/5336278c-bab7-11e5-8ce3-a9ccdd976062.png)
