### PR TITLE
Add comment icon & notification badge on User Story list

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -42,14 +42,16 @@
 $story-points-dimension: rem-calc(25);
 $story-padding-sides: rem-calc(15);
 $story-padding-top: rem-calc(20);
-
+$badge-dimension: rem-calc(7);
+$circle-dimension: $story-points-dimension;
 
 .backlog-user-story,
 #story-delete-modal,
 #story-detail-modal {
+  .icn-comments,
   .story-points,
   .story-actions {
-    @include border-radius(rem-calc(100%));
+    @include border-radius(100%);
     background: $black-10;
     font-size: rem-calc(12);
     height: $story-points-dimension;
@@ -60,14 +62,14 @@ $story-padding-top: rem-calc(20);
   } // span
 }//styles for backlog user story and modal
 
+.reorder-user-stories { &:last-child { border-bottom: 1px solid $black-10; } }
+
 .backlog-user-story {
   border-top: 1px solid $black-10;
   padding: $story-padding-top $story-padding-sides;
   position: relative;
 
   &:first-child { margin-top: rem-calc(30); }
-
-  &:last-child { border-bottom: 1px solid $black-10; }
 
   &:hover {
     background: $dashboard-hover-color;
@@ -76,11 +78,34 @@ $story-padding-top: rem-calc(20);
     .circle-checkbox { @include opacity(1); }
   }//backlog user story hover
 
-  .story-detail-link { display: block; }//story link to details
+  .icn-comments {
+    font-size: rem-calc(13);
+    right: $story-padding-sides;
+    top: $story-padding-top;
+    vertical-align: top;
+
+    &:hover { @include opacity(.8); }
+  } // comment icon
+
+  .notification-badge {
+    @include border-radius(100%);
+    background: $canvas-color;
+    display: block;
+    height: $badge-dimension;
+    position: absolute;
+    right: -1px;
+    top: 0;
+    width: $badge-dimension;
+  }
+
+  .story-detail-link {
+    display: block;
+    position: relative;
+  }//story link to details
 
   .story-text {
     @include inline-block();
-    padding-left: $story-points-dimension + $story-padding-sides;
+    padding: 0 ($story-points-dimension + $story-padding-sides);
   } // text
 
   .circle-checkbox {

--- a/app/views/arbor_reloaded/user_stories/_user_story.haml
+++ b/app/views/arbor_reloaded/user_stories/_user_story.haml
@@ -10,3 +10,5 @@
       %span= user_story.action
       %span.grey-prefix= t('reloaded.backlog.result')
       %span= user_story.result
+    = link_to '#', class: 'icn-comments' do
+      %span.notification-badge

--- a/spec/features/arbor_reloaded/user_story/comment_icon_spec.rb
+++ b/spec/features/arbor_reloaded/user_story/comment_icon_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+feature 'Comment icon link with notification badge on User Story list' do
+  let!(:user)         { create :user }
+  let!(:project)      { create :project, owner: user }
+  let!(:user_story)   { create :user_story, project: project }
+
+  background do
+    sign_in user
+    visit arbor_reloaded_project_user_stories_path(project)
+  end
+
+  scenario 'Should be able to see the comment icon at the right of the user story' do
+    within '.backlog-user-story' do
+      expect(page).to have_css('.icn-comments')
+    end
+  end
+end


### PR DESCRIPTION
## Add Comment icon & red badge notification on User Story list
#### Trello board reference:
- [Trello Card #57](https://trello.com/c/CkoRKf6F/385-57-3-as-a-user-i-should-be-able-to-see-if-i-have-any-new-comments-on-a-user-story-so-that-i-can-be-motivated-to-go-see-the-full-)

---
#### Description:
- As a user I should be able to see if I have any new comments on a user story so that I can be motivated to go see the full user story

---
#### Reviewers:
- @doshi @mojouy :sparkles: 

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-01-14 at 5 38 10 p m](https://cloud.githubusercontent.com/assets/6147409/12336879/9ca005e0-bae5-11e5-9262-4f9f6f15d6c5.png)
