### PR TITLE
Story/367/delete acceptance criteria

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/user_story_modal.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/user_story_modal.js
@@ -91,7 +91,10 @@ function UserStory() {
       $('.show-criterion').removeClass('inactive');
       $(this).find('.show-criterion').addClass('inactive');
       $('.edit-criterion').removeClass('active');
+      $('#acceptance-list .delete-criterion').removeClass('active');
+
       $(this).find('.edit-criterion').addClass('active');
+      $('#acceptance-list .delete-criterion[data-id='+ $(this).data('id') +']').addClass('active');
       return false;
     });
 
@@ -99,6 +102,7 @@ function UserStory() {
       if ($('.show-criterion').hasClass('inactive')) {
         $('.show-criterion').removeClass('inactive');
         $('.edit-criterion').removeClass('active');
+        $('.delete-criterion').removeClass('active');
       }
     });
   }

--- a/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_story_detail_modal.scss
@@ -173,7 +173,8 @@
     &.inactive { display: none; }
   }
 
-  .edit-criterion {
+  .edit-criterion,
+  .delete-criterion {
     display: none;
 
     &.active { display: block; }

--- a/app/controllers/arbor_reloaded/acceptance_criterions_controller.rb
+++ b/app/controllers/arbor_reloaded/acceptance_criterions_controller.rb
@@ -1,7 +1,7 @@
 module ArborReloaded
   class AcceptanceCriterionsController < ApplicationController
     before_action :set_user_story, only: [:create]
-    before_action :load_acceptance_criterion, only: [:update]
+    before_action :load_acceptance_criterion, only: [:update, :destroy]
 
     def create
       ac_service = CriterionServices.new(@user_story)
@@ -11,6 +11,11 @@ module ArborReloaded
 
     def update
       @acceptance_criterion.update_attributes(acceptance_criterion_params)
+    end
+
+    def destroy
+      @user_story = @acceptance_criterion.user_story
+      @acceptance_criterion.destroy
     end
 
     private

--- a/app/views/arbor_reloaded/acceptance_criterions/_acceptance_criterion.haml
+++ b/app/views/arbor_reloaded/acceptance_criterions/_acceptance_criterion.haml
@@ -1,6 +1,9 @@
-.criterion
+.criterion{data: { id: acceptance_criterion.id } }
   .show-criterion{data: { id: acceptance_criterion.id } }
     %li=acceptance_criterion.description
   .edit-criterion{data: { id: acceptance_criterion.id } }
     = render 'arbor_reloaded/acceptance_criterions/edit_criterion',
     acceptance_criterion: acceptance_criterion
+.delete-criterion{data: { id: acceptance_criterion.id } }
+  = link_to arbor_reloaded_acceptance_criterion_path(acceptance_criterion), remote: true, method: :delete do
+    %span.icn-delete

--- a/app/views/arbor_reloaded/acceptance_criterions/_index.haml
+++ b/app/views/arbor_reloaded/acceptance_criterions/_index.haml
@@ -1,0 +1,4 @@
+%ul#acceptance-list
+  - user_story.acceptance_criterions.each do |criterion|
+    = render 'arbor_reloaded/acceptance_criterions/acceptance_criterion',
+    acceptance_criterion: criterion

--- a/app/views/arbor_reloaded/acceptance_criterions/destroy.js.erb
+++ b/app/views/arbor_reloaded/acceptance_criterions/destroy.js.erb
@@ -1,0 +1,2 @@
+$('.criterions-container').empty().html("<%= j render 'arbor_reloaded/acceptance_criterions/index', user_story: @user_story %>");
+UserStory();

--- a/app/views/arbor_reloaded/user_stories/show.haml
+++ b/app/views/arbor_reloaded/user_stories/show.haml
@@ -41,10 +41,8 @@
     %h6.story-section-title= t('reloaded.story_modal.acceptance_criteria.title')
     = render 'arbor_reloaded/acceptance_criterions/form',
     criterion: [:arbor_reloaded, @user_story, AcceptanceCriterion.new]
-    %ul#acceptance-list
-      - @user_story.acceptance_criterions.each do |criterion|
-        = render 'arbor_reloaded/acceptance_criterions/acceptance_criterion',
-        acceptance_criterion: criterion
+    .criterions-container
+      = render 'arbor_reloaded/acceptance_criterions/index', user_story: @user_story
   %section.comments.story-modal-section
     %h6.story-section-title= t('reloaded.story_modal.comments.title')
     = render 'arbor_reloaded/comments/form', comment: [:arbor_reloaded, @user_story, Comment.new]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,7 @@ Railsroot::Application.routes.draw do
           only: [:create, :index, :show, :update, :destroy],
           as: :user_stories,
           controller: :user_stories do
-        resources :acceptance_criterions, only: [:create, :update]
+        resources :acceptance_criterions, only: [:create, :update, :destroy]
         resources :constraints, only: [:create, :update]
         resources :tags, only: [:create, :index]
         resources :comments, only: [:create]

--- a/spec/controllers/arbor_reloaded/acceptance_criterions_controller_spec.rb
+++ b/spec/controllers/arbor_reloaded/acceptance_criterions_controller_spec.rb
@@ -24,4 +24,13 @@ RSpec.describe ArborReloaded::AcceptanceCriterionsController do
       expect(AcceptanceCriterion.last.description).to eq('My new description')
     end
   end
+
+  describe 'DELETE destroy' do
+    let!(:acceptance_criterion) { create :acceptance_criterion, user_story: user_story }
+
+    it 'deletes the criterion' do
+      delete :destroy, format: :js, id: acceptance_criterion.id
+      expect(AcceptanceCriterion.exists? acceptance_criterion.id).to be_falsy
+    end
+  end
 end

--- a/spec/features/arbor_reloaded/acceptance_criterion_spec.rb
+++ b/spec/features/arbor_reloaded/acceptance_criterion_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+feature 'Acceptance criterions', js:true do
+  let!(:user)       { create :user }
+  let!(:project)    { create :project, owner: user }
+  let!(:user_story) { create :user_story, project: project }
+  let!(:criterion)  { create :acceptance_criterion, user_story: user_story }
+
+  background do
+    sign_in user
+    visit arbor_reloaded_project_user_stories_path(project)
+    find('.story-detail-link').trigger('click')
+  end
+
+  scenario 'should be able to delete a criterion' do
+    within '#story-detail-modal' do
+      find('.criterion').trigger('click')
+      find('.icn-delete').trigger('click')
+    end
+    wait_for_ajax
+    expect(AcceptanceCriterion.count).to eq 0
+  end
+end


### PR DESCRIPTION
## Delete an acceptance criteria
#### Trello board reference:
- [Trello Card #70](https://trello.com/c/uLPoPn33/367-70-2-as-a-user-i-should-be-able-to-delete-an-acceptance-criteria-so-that-i-can-get-rid-of-it)

---
#### Description:
- When you click on an ac to edit it, the trash can appears so that you can delete it.
  Controller and feature tests.

---
#### Risk:
- Medium

---
#### Preview:
- N/A
