### PR TITLE
Add missing line after update

### DIFF
--- a/app/views/arbor_reloaded/acceptance_criterions/update.js.erb
+++ b/app/views/arbor_reloaded/acceptance_criterions/update.js.erb
@@ -1,4 +1,5 @@
 $('.edit-criterion[data-id="<%= @acceptance_criterion.id %>"]').removeClass('active');
+$('#acceptance-list .delete-criterion[data-id="<%= @acceptance_criterion.id %>"]').removeClass('active');
 
 $show_criterion = $('.show-criterion[data-id="<%= @acceptance_criterion.id %>"]');
 $show_criterion.removeClass('inactive');


### PR DESCRIPTION
## Fix trash can appearing after edit.
#### Trello board reference:
- [Trello Card #367](https://trello.com/c/uLPoPn33/367-70-2-as-a-user-i-should-be-able-to-delete-an-acceptance-criteria-so-that-i-can-get-rid-of-it)

---
#### Description:
- After updating an acceptance criteria the trash can remained on sight and it should hide. This fixes it.

---
#### Risk:
- Low

---
