### PR TITLE
Add missing number 3 from fibonacci numbers, test.

### DIFF
--- a/app/views/arbor_reloaded/user_stories/show.haml
+++ b/app/views/arbor_reloaded/user_stories/show.haml
@@ -10,10 +10,11 @@
       %select.fibonacci-select{ id: 'fibonacci-dropdown',
       data: { id: @user_story.id, url: arbor_reloaded_user_story_path(@user_story) } }
         %option{ value: '?' } ?
-        %option{ value: '1', selected: (@user_story.estimated_points == 1)} 1
+        %option{ value: '1', selected: (@user_story.estimated_points == 1) } 1
         %option{ value: '2', selected: (@user_story.estimated_points == 2) } 2
+        %option{ value: '3', selected: (@user_story.estimated_points == 3) } 3
         %option{ value: '5', selected: (@user_story.estimated_points == 5) } 5
-        %option{ value: '8', selected: (@user_story.estimated_points == 8)} 8
+        %option{ value: '8', selected: (@user_story.estimated_points == 8) } 8
         %option{ value: '13', selected: (@user_story.estimated_points == 13) } 13
         %option{ value: '21', selected: (@user_story.estimated_points == 21) } 21
 

--- a/spec/features/arbor_reloaded/user_story/story_detail_spec.rb
+++ b/spec/features/arbor_reloaded/user_story/story_detail_spec.rb
@@ -12,20 +12,24 @@ feature 'Story detail modal', js:true do
   end
 
   scenario 'should display the details modal' do
-    skip 'This test fails because we hide a section which still requires backend work so we are hiding it'
     expect(page).to have_css('#story-detail-modal')
   end
 
   scenario 'should be able to estimate a story' do
-    skip 'This test fails because we hide a section which still requires backend work so we are hiding it'
     find('#fibonacci-dropdown').find('option[value="13"]').select_option
     wait_for_ajax
     user_story.reload
     expect(user_story.estimated_points).to eq(13)
   end
 
+  scenario 'the estimation includes the first 7 fibonacci numbers' do
+    options = find('#fibonacci-dropdown').all('option').collect(&:value)
+    fibonacci_numbers = UserStory.estimation_series.map(&:to_s)
+
+    expect(options[1..-1]).to eq(fibonacci_numbers[1..-1])
+  end
+
   scenario 'should be able to edit a story' do
-    skip 'This test fails because we hide a section which still requires backend work so we are hiding it'
     within '#story-detail-modal' do
       find('.sentence').click
       fill_in 'role-input', with: 'developer'
@@ -37,7 +41,6 @@ feature 'Story detail modal', js:true do
   end
 
   scenario 'should be able to see other actions' do
-    skip 'This test fails because we hide a section which still requires backend work so we are hiding it'
     find('.story-actions').click
     within '#story-detail-modal' do
       expect(page).to have_css('a.icn-delete')


### PR DESCRIPTION
## Missing 3 on fibonacci estimation sequence
#### Trello board reference:
- [Trello Card #67](https://trello.com/c/O520X7qF/392-67-3-as-a-user-i-should-be-able-to-estimate-a-user-story-so-that-i-can-properly-size-it)

---
#### Description:
- The number 3 was missing from the options. Fixed the bug and include a test so that in the future it doesn't happen again.

---
#### Risk:
- Low

---
