### PR TITLE
Removed Add new collaborator log line from activities, in the reloade…

### DIFF
--- a/app/views/public_activity/project/_add_member.haml
+++ b/app/views/public_activity/project/_add_member.haml
@@ -7,3 +7,5 @@
   .log-action
     - if activity.parameters[:element]
       = activity.parameters[:element] + t("log.#{activity.key}")
+    - else
+      = t('log.add_member_no_info')


### PR DESCRIPTION
## Feedback: remove A new collaborator log line form the activities view rendering
#### Trello board reference:
- [Trello Card #83](https://trello.com/c/WWCjhUlI)

---
#### Description:
- I have removed the 'A new collaborator...' line from the log page for the reloaded version

---
#### Reviewers:
- @damian

---
#### Notes:
- 

---
#### Tasks:
- [x] Remove add new collaborator from log chain

---
#### Risk:
- Low

---
#### Preview:
- N/A
