### PR TITLE
Separate log in and sign up views.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,10 +3,6 @@ class RegistrationsController < Devise::RegistrationsController
   skip_before_action :authenticate_user!
   after_action :add_member_to_projects, only: :create
 
-  def new
-    redirect_to new_user_session_path
-  end
-
   def create # rubocop:disable all
     build_resource(sign_up_params)
 

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -5,7 +5,6 @@ class InviteMailer < ActionMailer::Base
     @project_name = data[:project_name]
     @inviter = data[:inviter]
     @is_new = is_new
-    @link_url = root_url
 
     attachments.inline['logo.png'] = File.read(
       File.join Rails.root, 'public', 'arbor-logo.png'

--- a/app/views/devise/registrations/_sign_up.haml
+++ b/app/views/devise/registrations/_sign_up.haml
@@ -18,3 +18,5 @@
       required: true
     .action
       = f.submit t('sign_up.button_signup'), class: 'button radius success small'
+  Already have an account?
+  = link_to 'Log in', new_user_session_path, class: 'link'

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -1,10 +1,6 @@
-%section#user-session
+#user-session
   .arbor-logo
     = image_tag('arbor-logo.svg')
   .row
-    .large-6.columns
-      .login-form
-        = render 'devise/sessions/login'
-    .large-6.columns
-      .signup-form
-        = render 'devise/registrations/sign_up'
+    .signup-form
+      = render 'devise/registrations/sign_up'

--- a/app/views/devise/sessions/_login.haml
+++ b/app/views/devise/sessions/_login.haml
@@ -14,3 +14,5 @@
     .action
       = f.submit t('login.button_login'), class: 'button radius success small', id: 'login_button'
   = render 'devise/shared/links'
+  Don't have an account yet?
+  = link_to 'Sign up', new_user_registration_path, class: 'link'

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -2,9 +2,5 @@
   .arbor-logo
     = image_tag('arbor-logo.svg')
   .row
-    .large-6.columns
-      .login-form
-        = render 'devise/sessions/login'
-    .large-6.columns
-      .signup-form
-        = render 'devise/registrations/sign_up'
+    .login-form
+      = render 'devise/sessions/login'

--- a/app/views/invite_mailer/project_invite_email.html.haml
+++ b/app/views/invite_mailer/project_invite_email.html.haml
@@ -20,9 +20,9 @@
                   - if @is_new
                     %tr{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; margin: 0; padding: 0;"}
                       %td.padding{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; text-align: center; line-height: 1.6; margin: 0; padding: 10px 0;"}
-                        = link_to t("mailer.invite.create_account"), @link_url, {:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.5; color: #FFF; text-decoration: none; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background: #2ecc71; margin: 10px auto; padding: 0; border-color: #2ecc71; width: 93%; border-style: solid; border-width: 10px 20px;"}
+                        = link_to t("mailer.invite.create_account"), new_user_registration_path, {:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.5; color: #FFF; text-decoration: none; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background: #2ecc71; margin: 10px auto; padding: 0; border-color: #2ecc71; width: 93%; border-style: solid; border-width: 10px 20px;"}
                   - else
-                    %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= link_to t("mailer.invite.view_project"), root_url
+                    %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= link_to t("mailer.invite.view_project"), new_user_session_path
                   %table
                     %tr
                       %p{:style => "font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0; color: #747474;"}= t("mailer.invite.thanks").html_safe

--- a/spec/features/landing_page/signup_spec.rb
+++ b/spec/features/landing_page/signup_spec.rb
@@ -3,14 +3,15 @@ require 'spec_helper'
 feature 'Sign up to Arbor' do
   let(:user) { build :user }
 
-  scenario 'should show me the minimum password length when I enter' do
-    visit new_user_session_path
+  background do
+    visit new_user_registration_path
+  end
 
+  scenario 'should show me the minimum password length when I enter' do
     expect(page).to have_content 'Minimum 8 characters'
   end
 
   scenario 'should sign me up when I enter all credentials correctly' do
-    visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
       fill_in :user_email, with: user.email
@@ -24,7 +25,6 @@ feature 'Sign up to Arbor' do
   end
 
   scenario 'should not show me the signup successful message' do
-    visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
       fill_in :user_email, with: user.email
@@ -38,7 +38,6 @@ feature 'Sign up to Arbor' do
   end
 
   scenario 'should show me an error when I enter mismatching passwords' do
-    visit new_user_session_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
       fill_in :user_email, with: user.email
@@ -52,7 +51,7 @@ feature 'Sign up to Arbor' do
   end
 
   scenario 'should show me an error when I enter too short passwords' do
-    visit new_user_session_path
+    visit new_user_registration_path
     within '#signup' do
       fill_in :user_full_name, with: user.full_name
       fill_in :user_email, with: user.email


### PR DESCRIPTION
## Separates the sign up and log in views
#### Trello board reference:
- [Trello Card #103](https://trello.com/c/cIp7exbi/482-103-3-as-a-user-i-should-be-able-separate-sign-up-and-log-in-for-arbor)

---
#### Description:
- \* Adds links in both views to the other one
- Modifies email invites to match new destination views
- Fixes tests.
#### Risk:
- Medium

---
