### PR TITLE
Add error message on project creation.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -41,3 +41,10 @@ function generalBinds() {
     bindProjectsFilter();
   }
 }
+
+function bindAutoReveal() {
+  $('div[data-auto-reveal]').foundation('reveal', 'open');
+  $('#create-project-btn').click(function() {
+    $('#project-modal').foundation('reveal', 'open');
+  });
+}

--- a/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
@@ -37,4 +37,5 @@ function displayHideDelete() {
 
 $( document ).ready(function() {
   generalBinds();
+  bindAutoReveal();
 });

--- a/app/assets/stylesheets/arbor_reloaded/_new_project_modal.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_new_project_modal.scss
@@ -1,12 +1,18 @@
 // NEW PROJECT MODALS
 // - - - - - - - - - - - - - - - - - - - - - - - - -
-
 #project-modal {
   .project-name {
     font-size: rem-calc(14);
-    margin: rem-calc(35) auto;
+    margin: rem-calc(35) auto rem-calc(10);
     text-align: center;
 
     @include input-placeholder { font-size: rem-calc(14); }
   }//project name input
+
+  .errors {
+    color: $canvas-color;
+    font-family: $font-family-sans-serif;
+    font-size: rem-calc(14);
+    margin-bottom: rem-calc(30);
+  }
 }//project modal

--- a/app/controllers/arbor_reloaded/projects_controller.rb
+++ b/app/controllers/arbor_reloaded/projects_controller.rb
@@ -7,6 +7,7 @@ module ArborReloaded
     def index
       scope = params[:project_order] || 'recent'
       @projects = @projects.send(scope)
+      @new_project = Project.new
       render layout: 'application_reload'
     end
 
@@ -78,8 +79,8 @@ module ArborReloaded
     end
 
     def create
-      @project = Project.new(project_params)
-      @project.owner = current_user
+      @new_project = Project.new(project_params)
+      @new_project.owner = current_user
       assist_creation
     end
 
@@ -140,6 +141,7 @@ module ArborReloaded
     end
 
     def html_update
+      @new_project = @project
       assign_associations
       if @project.save
         redirect_to :back
@@ -155,13 +157,12 @@ module ArborReloaded
     end
 
     def assist_creation
-      if @project.save
-        @project.create_activity :create_project
+      if @new_project.save
+        @new_project.create_activity :create_project
         assign_associations
-        redirect_to arbor_reloaded_project_user_stories_path(@project)
+        redirect_to arbor_reloaded_project_user_stories_path(@new_project)
       else
-        @errors = @project.errors.full_messages
-        render :new, status: 400
+        render 'arbor_reloaded/projects/index', layout: 'application_reload'
       end
     end
 
@@ -180,9 +181,9 @@ module ArborReloaded
     end
 
     def assign_associations
-      @project.owner ||= current_user
+      @new_project.owner ||= current_user
       ProjectMemberServices.new(
-        @project, current_user, member_emails
+        @new_project, current_user, member_emails
       ).invite_members
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,9 @@ class Project < ActiveRecord::Base
   include PublicActivity::Common
 
   validates_presence_of :name
-  validates_uniqueness_of :name, scope: :owner
+  validates_uniqueness_of :name,
+                          scope: :owner,
+                          message: 'Project name already exists'
   validates_uniqueness_of :slack_channel_id, allow_nil: true
 
   belongs_to :owner, class_name: User

--- a/app/views/arbor_reloaded/projects/index.haml
+++ b/app/views/arbor_reloaded/projects/index.haml
@@ -9,10 +9,15 @@
       %p= t('reloaded.project_dashboard.get_started')
       =link_to t('reloaded.project_dashboard.create_button'), '#', class: 'button radius small', data: { reveal_id: 'project-modal' }
 
-#project-modal.reveal-modal{"aria-hidden" => "true", "aria-labelledby" => "project-modal", "data-reveal" => "", :role => "dialog"}
+#project-modal.reveal-modal{'aria-hidden' => 'true', 'aria-labelledby' => 'project-modal', 'data-reveal' => '', 'data-auto-reveal' => @new_project.errors.present?, :role => 'dialog' }
   = link_to '×', '#', class: 'close-reveal-modal'
-  = form_for :project, url: '/arbor_reloaded/projects', html: { id: 'new_project' }  do |f|
+  = form_for @new_project, url: '/arbor_reloaded/projects', html: { id: 'new_project' }  do |f|
     %h2= t('reloaded.create_project.title')
     = f.text_field :name, placeholder: t('reloaded.create_project.project_name'), class: 'project-name radius login'
+    %ul
+      - @new_project.errors.each do |attr, msg|
+        %li.errors
+          *
+          = msg
     .action
       = f.submit t('create_project.save_button'), class: 'button radius tiny'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,7 +5,7 @@ describe Project do
   subject       { project }
 
   it { should validate_presence_of :name }
-  it { should validate_uniqueness_of(:name).scoped_to(:owner_id) }
+  it { should validate_uniqueness_of(:name).scoped_to(:owner_id).with_message('Project name already exists') }
   it { should validate_uniqueness_of(:slack_channel_id) }
   it { should have_many :invites }
   it { should have_many :members }


### PR DESCRIPTION
## Bug: Need error message for creating project with same name as other project you own. Currently it takes you to an site error page instead
#### Trello board reference:
- [Trello Card #452](https://trello.com/c/7x2qBjN3/425-3-bug-need-error-message-for-creating-project-with-same-name-as-other-project-you-own-currently-it-takes-you-to-an-site-error-pa)

---
#### Description:
- Add an error message when trying to create a duplicated project name

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
