### PR TITLE
Reset password view

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -7,6 +7,8 @@ a { color: $secondary-color; }
 ul { margin: 0; }
 li { list-style: none; }
 
+input { outline: 0; }
+
 // CIRCULAR CHECKBOX
 
 .circle-checkbox {
@@ -46,6 +48,12 @@ li { list-style: none; }
 .ui-helper-hidden-accessible { display: none; } // hide default search result text coming from the jquery widget
 
 .grey-prefix { color: $black-40; }
+
+.button.secondary {
+  background-color: $black-10;
+  color: $black-80;
+  margin-left: $button-margin-bottom;
+} // secondary grey btn
 
 // -------  BASE FORM STYLES ------ //
 

--- a/app/assets/stylesheets/arbor_reloaded/_modals.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_modals.scss
@@ -72,10 +72,4 @@ $modal-close-offset: rem-calc(20);
     padding: $modal-close-offset $modal-sides-padding 0;
     text-align: center;
   }
-
-  .secondary {
-    background-color: $black-10;
-    color: $black-80;
-    margin-left: $button-margin-bottom;
-  } // secondary btn
 }//reveal modal

--- a/app/views/arbor_reloaded/navigation/_user_nav.html.haml
+++ b/app/views/arbor_reloaded/navigation/_user_nav.html.haml
@@ -3,6 +3,6 @@
     %li= link_to t('reloaded.navigation.settings'), '#', class: 'link'
     %li= link_to t('reloaded.navigation.profile'), '#', class: 'link'
     %li= link_to t('reloaded.navigation.people'), arbor_reloaded_team_path, class: 'link'
-    %li= link_to t('reloaded.navigation.change_password'), '#', class: 'link'
+    %li= link_to t('reloaded.navigation.change_password'), edit_user_registration_path, class: 'link', locals: {version: 'reloaded'}
   %ul.right.members
     %li= link_to '-', '#', { class: 'add-member' }

--- a/app/views/arbor_reloaded/users/edit_password.html.haml
+++ b/app/views/arbor_reloaded/users/edit_password.html.haml
@@ -1,0 +1,11 @@
+= render 'arbor_reloaded/navigation/user_nav'
+= render 'arbor_reloaded/users/user_header'
+.change-password.row
+  .title-breaker
+    %h5= t('reloaded.users.profile')
+  .edit-inputs
+    %input.enter-password{ type: 'password', placeholder: t('reloaded.users.enter_password') }
+    %input.confirm-password{ type: 'password', placeholder: t('reloaded.users.confirm_password') }
+  %input.current-password{ type: 'password', placeholder: t('reloaded.users.current_password') }
+  = link_to t('reloaded.users.save_btn'),'#', class: 'button tiny radius'
+  = link_to t('reloaded.users.cancel_btn'),'#', class: 'button tiny radius secondary'

--- a/app/views/arbor_reloaded/users/show.html.haml
+++ b/app/views/arbor_reloaded/users/show.html.haml
@@ -8,5 +8,6 @@
   %h5.mail-title= t('reloaded.users.mail')
   %span.user-mail
     = current_user.email
-  = link_to t('reloaded.users.edit'),'#', class: 'button radius tiny', id: 'edit-profile-btn'
-  = link_to t('reloaded.users.cancel'),'#', class: 'cancel-link'
+  = link_to t('reloaded.users.edit'), '#', class: 'button radius tiny', id: 'edit-profile-btn'
+  .hide
+    = link_to t('reloaded.users.cancel'), '#', class: 'cancel-link'

--- a/app/views/devise/registrations/edit.haml
+++ b/app/views/devise/registrations/edit.haml
@@ -1,34 +1,47 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name),
-html: { method: :put }) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, required: true
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: 'off', required: true
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: 'off',
-    required: true
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: 'off', required: true
-  .actions
-    = f.submit 'Update'
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to 'Cancel my account', registration_path(resource_name),
-  data: { confirm: 'Are you sure?' }, method: :delete}
-= link_to 'Back', :back
+- if local_assigns.has_key?(:version) && local_assigns[:version] == 'reloaded'
+  = render 'arbor_reloaded/navigation/user_nav'
+  = render 'arbor_reloaded/users/user_header'
+  .change-password.row
+    .title-breaker
+      %h5= t('reloaded.users.profile')
+    .edit-inputs
+      %input.enter-password{ type: 'password', placeholder: t('reloaded.users.enter_password') }
+      %input.confirm-password{ type: 'password', placeholder: t('reloaded.users.confirm_password') }
+    %input.current-password{ type: 'password', placeholder: t('reloaded.users.current_password') }
+    = link_to t('reloaded.users.save_btn'),'#', class: 'button tiny radius'
+    = link_to t('reloaded.users.cancel_btn'),'#', class: 'button tiny radius secondary'
+- else
+  %h2
+    Edit #{resource_name.to_s.humanize}
+  = form_for(resource, as: resource_name, url: registration_path(resource_name),
+  html: { method: :put }) do |f|
+    = devise_error_messages!
+    .field
+      = f.label :email
+      %br/
+      = f.email_field :email, autofocus: true, required: true
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      %div
+        Currently waiting confirmation for: #{resource.unconfirmed_email}
+    .field
+      = f.label :password
+      %i (leave blank if you don't want to change it)
+      %br/
+      = f.password_field :password, autocomplete: 'off', required: true
+    .field
+      = f.label :password_confirmation
+      %br/
+      = f.password_field :password_confirmation, autocomplete: 'off',
+      required: true
+    .field
+      = f.label :current_password
+      %i (we need your current password to confirm your changes)
+      %br/
+      = f.password_field :current_password, autocomplete: 'off', required: true
+    .actions
+      = f.submit 'Update'
+  %h3 Cancel my account
+  -# %p
+  -#   Unhappy? #{button_to 'Cancel my account', registration_path(resource_name),
+  -#   data: { confirm: 'Are you sure?' }, method: :delete}
+  = link_to 'Back', :back

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,3 +278,8 @@ en:
       mail: 'Email'
       edit: 'Edit'
       cancel: 'Cancel my account'
+      save_btn: 'Save'
+      cancel_btn: 'Cancel'
+      enter_password: 'Enter new password'
+      confirm_password: 'Confirm password'
+      current_password: 'Current password'


### PR DESCRIPTION
Add input's styles for password view
## Reset password view
#### Trello board reference:
- [Trello Card #95](https://trello.com/c/BYnN49we/491-95-3-as-a-user-i-should-be-able-to-update-my-profile)

---
#### Description:
- As a User I should be able to reset my password

---
#### Reviewers:
- @mojo

---
#### Notes:

This view is on  /arbor_reloaded/users/edit_password.html.haml but we couldn't link it to Change Password. Ale is going to add it through Devise.  
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-01-22 at 11 34 28 a m](https://cloud.githubusercontent.com/assets/6147409/12513428/78239070-c0fc-11e5-8748-6d9c3db20e82.png)
