### PR TITLE
Add red border to errors on project modal input.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -44,6 +44,7 @@ function generalBinds() {
 
 function bindAutoReveal() {
   $('div[data-auto-reveal]').foundation('reveal', 'open');
+  $('div[data-auto-reveal]').addClass('with-errors');
   $('#create-project-btn').click(function() {
     $('#project-modal').foundation('reveal', 'open');
   });

--- a/app/assets/stylesheets/arbor_reloaded/_new_project_modal.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_new_project_modal.scss
@@ -15,4 +15,8 @@
     font-size: rem-calc(14);
     margin-bottom: rem-calc(30);
   }
+
+  &.with-errors {
+    .project-name { border-color: $canvas-color;}
+  }
 }//project modal


### PR DESCRIPTION
## Need error message for creating project with same name as other project you own. Currently it takes you to an site error page instead.
#### Trello board reference:
- [Trello Card #425](https://trello.com/c/7x2qBjN3/425-3-bug-need-error-message-for-creating-project-with-same-name-as-other-project-you-own-currently-it-takes-you-to-an-site-error-pa)

---
#### Description:
- 

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
