### PR TITLE
Add show and hide estimation dependent on user stories.

### DIFF
--- a/app/assets/javascripts/application-reloaded.js
+++ b/app/assets/javascripts/application-reloaded.js
@@ -25,6 +25,7 @@
 //= require arbor-reloaded/projects/user_story_modal
 //= require arbor-reloaded/projects/copy_user_story_modal
 //= require arbor-reloaded/user_stories/delete_from_modal
+//= require arbor-reloaded/user_stories/estimation
 //= require arbor-reloaded/projects/actions/SlackModalActions
 //= require arbor-reloaded/projects/stores/SlackModalStore
 //= require arbor-reloaded/utils/canvases/canvases

--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -69,4 +69,5 @@ function backlogGeneralBinds() {
   showBulkMenu();
   bindReorderStories();
   autogrowInputs();
+  checkEstimation();
 }

--- a/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
+++ b/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
@@ -1,0 +1,7 @@
+function checkEstimation() {
+  var estimation = $('.estimation.row');
+
+  if (estimation.hasClass( 'hide' )) {
+    estimation.removeClass('hide');
+  }
+}

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -1,6 +1,6 @@
 .new-backlog-story.row
   = render 'arbor_reloaded/user_stories/form', user_story: UserStory.new, project: @project
-.estimation.row
+.estimation.row{class: @project.user_stories.count > 0 ? 'visible' : 'hide'}
   = render 'arbor_reloaded/user_stories/estimation', project: @project, total_points: @total_points
 .backlog-story-list.row
   .sticky-menu


### PR DESCRIPTION
## Feedback
#### Trello board reference:
- [Trello Card #37](https://trello.com/c/zVYU4QL8/343-37-3-as-a-user-i-should-be-able-to-view-the-estimation-of-my-project)

---
#### Description:
- Add show and hide functionality to the estimation widget, dependent on the amount of stories

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
