### PR TITLE
Showing the join btn if you are not member of the project in the dashboard and navigation var

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_navigation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_navigation.scss
@@ -181,7 +181,7 @@ ul .dropdown {
   .members {
     margin-right: $topbar-margin;
 
-    a {
+    a:not(.button) {
       @include border-radius(100%);
       @include inline-block;
       background-size: cover;
@@ -225,7 +225,12 @@ ul .dropdown {
         width: rem-calc(30);
 
         @media #{$small-only} { display: none; }
-      }
-    }
-  }
+      }//other members
+    }//a
+
+    .button {
+      display: inline;
+      margin: 0;
+    }//button
+  }//members
 }//secondary nav

--- a/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
@@ -135,7 +135,12 @@ $search-width: rem-calc(300);
     border-bottom: 1px solid $black-10;
     position: relative;
 
-    &:not(.favorite-project) {
+    .join-btn {
+      display: none;
+      margin: 0;
+    }
+
+    &:not(.favorite-project):not(.not-member) {
       .project,
       .actions,
       .deleter { background-color: $white; }
@@ -144,6 +149,12 @@ $search-width: rem-calc(300);
         .favorite .icn-favorite-empty { @include inline-block; }
       }
     }//not favorite project entry
+
+    &.not-member {
+      &:hover {
+        .join-btn { @include inline-block; }
+      }
+    }//project user is no member
   }//project li
 
   // Project link

--- a/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
+++ b/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
@@ -143,5 +143,4 @@ $shadow-depth-hover: rgba($black-50, .2) 3px 8px 25px;
   overflow: hidden;
   white-space: nowrap;
 }
-
-.hidden-input-element { display: none !important; }
+.hidden-element { display: none !important; }

--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -44,6 +44,8 @@
       = link_to '+', |
       arbor_reloaded_project_members_path(current_project), |
       { class: 'add-member', data: { reveal_id: 'project-members-modal', reveal_ajax: true } }
+    -# TODO this link should only appear if the user is not a member of this project, and should't see the plus and members items, MOJO {remove .hidden-element for enable it}
+    %li= link_to t('reloaded.project_dashboard.join_project'), '#', class: 'button radius success tiny join-btn hidden-element'
 #project-members-modal.reveal-modal{ data: { reveal: '' } }
 %div
   = react_component('SlackModal', { url: arbor_reloaded_project_path(current_project), slackToken: current_project.slack_token, slackChannelId: current_project.slack_channel_id }, {prerender: false})

--- a/app/views/arbor_reloaded/projects/partials/_invite_member.haml
+++ b/app/views/arbor_reloaded/projects/partials/_invite_member.haml
@@ -1,9 +1,9 @@
 = form_for project, url:  arbor_reloaded_project_path(project), html: { id: 'edit_project' }  do |f|
-  = f.text_field :name, class: 'hidden-input-element'
+  = f.text_field :name, class: 'hidden-element'
   %input{ id: "member_#{project.members.count}", |
     class: 'new-member-mail radius', |
     name: "project[member_#{project.members.count}]", |
     type: "email", |
     required: true, |
     placeholder: t('reloaded.project_members.mail_invite')}
-  = f.submit id: 'submit-modal-form', class: 'hidden-input-element'
+  = f.submit id: 'submit-modal-form', class: 'hidden-element'

--- a/app/views/arbor_reloaded/projects/partials/_projects_list.haml
+++ b/app/views/arbor_reloaded/projects/partials/_projects_list.haml
@@ -31,11 +31,13 @@
             = link_to t('reloaded.project_dashboard.delete_project'), arbor_reloaded_project_path(project), method: :delete, class: 'button radius alert tiny'
             = link_to t('reloaded.project_dashboard.cancel'), '#', class: 'cancel'
   .title-breaker
-    %h5= t('reloaded.project_dashboard.all_projects', count: projects.non_favorite.count)
+    %h5= t('reloaded.project_dashboard.my_projects', count: projects.non_favorite.count)
   %ul.common-projects-list.white-blocks-list
     - projects.each do |project|
+      -# TODO add .not-member class to li if the project belongs to a team you're not in this will show the "Join as collaborator" btn, Mojo
       %li.white-block
         .right
+          = link_to t('reloaded.project_dashboard.join_project'), '#', class: 'button radius success tiny join-btn'
           = link_to '#', class: 'favorite-link favorite has-tip', aria: { haspopup: true }, title: t('reloaded.tooltips.favorite_project'), data: { url: arbor_reloaded_project_path(project), favorite: project.favorite, tooltip: '' } do
             %span.icn-favorite-empty
           = link_to '#', class: 'others' do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,7 @@ en:
       mail_invite: 'Invite members by email address...'
       close: 'Close'
     project_dashboard:
-      all_projects: 'All projects (%{count})'
+      my_projects: 'My Projects (%{count})'
       favorite: 'Favorite (%{count})'
       last_update: 'Last update:'
       no_projects: 'No projects yet'
@@ -242,6 +242,7 @@ en:
       are_you_sure: 'Are you sure?'
       are_you_sure2: 'Are you sure you want to delete:'
       delete_project: 'Yes, delete it'
+      join_project: 'Join as Collaborator'
       cancel: 'Cancel'
       search_input: 'Search'
       sort_by_recent: 'Sort by date'


### PR DESCRIPTION
[#449] Showing the join btn if you are not member of the project in the dashboard and navigation var

I'm just placing the "Join as Collaborator" btn in the secondary nav and dashboard list, I need the backend logic to show them or not, I left comments on each of those instances, also we need to split the dashboard projects into as many lists as teams.

/cc @vicocas @AlejandroFernandesAntunes @doshii 
## Tasks
- [ ] Needs backend logic.
## References
- https://trello.com/c/MRgDiCNU
## Risks

**Low.** 

![screen shot 2016-01-27 at 12 40 10 pm](https://cloud.githubusercontent.com/assets/2197908/12618580/40c127aa-c4f3-11e5-987d-9f80040297c4.png)
![screen shot 2016-01-27 at 12 40 41 pm](https://cloud.githubusercontent.com/assets/2197908/12618579/40b831fe-c4f3-11e5-9025-19d436a10a70.png)
