### PR TITLE
Fix activity log long entries.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_project_activities.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_activities.scss
@@ -35,6 +35,8 @@
       float: left;
     }
 
+    .log-details { width: calc(100% - 80px); }
+
     .avatar-circle {
       @include border-radius(100%);
       @include inline-block;
@@ -59,6 +61,8 @@
 
       .log-entity { font-size: 12px; }
     }
+
+    .log-line-right { max-width: calc(100% - 200px); }
 
     h2 {
       background-color: $light-bg;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160128140951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "acceptance_criterions", force: :cascade do |t|
     t.text     "description"
@@ -244,7 +243,6 @@ ActiveRecord::Schema.define(version: 20160128140951) do
     t.string   "full_name"
     t.boolean  "admin",                  default: false
     t.string   "slack_id"
-    t.string   "avatar"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
## Bug: Long Text on Activity throws off layout
#### Trello board reference:
- [Trello Card #531](https://trello.com/c/ODVhwIfn/531-bug-long-text-on-activity-throws-off-layout)

---
#### Description:
- 

---
#### Reviewers:
- 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
