### PR TITLE
Fix activity log long entries.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_project_activities.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_activities.scss
@@ -1,8 +1,10 @@
 //Activities
 .section-log {
   $avatar-dimension: rem-calc(50);
+  $avatar-margin: rem-calc(25);
   $log-line-created-width: rem-calc(135);
   $log-line-left-margin: rem-calc(30);
+  $log-line-total-with: $log-line-created-width + $log-line-left-margin;
 
   margin-top: rem-calc(30);
 
@@ -19,10 +21,9 @@
     position: relative;
 
     .log-line-left {
-      @include clearfix;
       @include inline-block;
-      margin-right: $log-line-left-margin;
-      width: $log-line-created-width + $log-line-left-margin;
+      margin-right: 0;
+      width: $log-line-total-with;
 
       .created-at {
         margin-top: $avatar-dimension / 3;
@@ -35,6 +36,8 @@
       float: left;
     }
 
+    .log-details { width: calc(100% - ( #{$avatar-dimension} + #{$avatar-margin})); }
+
     .avatar-circle {
       @include border-radius(100%);
       @include inline-block;
@@ -43,7 +46,7 @@
       font-size: rem-calc(24);
       height: $avatar-dimension;
       line-height: $avatar-dimension;
-      margin-right: rem-calc(25);
+      margin-right: $avatar-margin;
       text-align: center;
       width: $avatar-dimension;
     }
@@ -58,6 +61,11 @@
       float: left;
 
       .log-entity { font-size: 12px; }
+    }
+
+    .log-line-right {
+      @include clearfix;
+      width: calc(100% - (#{$log-line-total-with} + #{$log-line-left-margin}));
     }
 
     h2 {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160128140951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "acceptance_criterions", force: :cascade do |t|
     t.text     "description"
@@ -244,7 +243,6 @@ ActiveRecord::Schema.define(version: 20160128140951) do
     t.string   "full_name"
     t.boolean  "admin",                  default: false
     t.string   "slack_id"
-    t.string   "avatar"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
## Bug on long log entries on activity view.
#### Trello board reference:
- [Trello Card #531](https://trello.com/c/ODVhwIfn/531-531-bug-long-text-on-activity-throws-off-layout)

---
#### Description:
- 

---
#### Reviewers:
- @rosinanabazas 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
