### PR TITLE
Fix uniqueness validation for team

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,6 @@
 class Team < ActiveRecord::Base
-  validates_uniqueness_of :name
   validates_presence_of :name
+  validates_presence_of :owner
 
   has_many :team_users
   has_many :users, through: :team_users

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
       save: 'Create Team'
       modal:
         mail_invite: 'Invite members by email address'
+      name_uniqueness: 'You are member of a team with that name, choose a different one.'
     estimation:
       separator_title: 'Estimation'
       save_button: 'Save Changes'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20160128140951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "acceptance_criterions", force: :cascade do |t|
     t.text     "description"

--- a/spec/features/arbor_reloaded/teams/create_spec.rb
+++ b/spec/features/arbor_reloaded/teams/create_spec.rb
@@ -24,4 +24,25 @@ feature 'Create a new team', js: true do
       expect(page).to have_content 'Test team'
     end
   end
+
+  context 'by a user that has a team with that name' do
+    let!(:team) { create :team, users: [user], name: 'Test team' }
+
+    scenario 'should not save the team' do
+      visit current_path
+
+      find('#new-team-button').trigger('click')
+      within 'form.new_team' do
+        fill_in(:team_name, with: 'Test team')
+        find('input#save-team').trigger('click')
+      end
+
+      within 'form.new_team' do
+        expect(page).to have_content('You are member of a team with that name, choose a different one.')
+      end
+
+      expect(Team.count).to eq(1)
+      expect(Team.first.id).to eq(team.id)
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Team, type: :model do
   subject    { team }
 
   it { should validate_presence_of :name }
-  it { should validate_uniqueness_of(:name) }
+  it { should validate_presence_of :owner }
   it { should have_many :users }
   it { should belong_to :owner }
   it { should have_many :projects }


### PR DESCRIPTION
## Fixes uniqueness validation according to AC
#### Trello board reference:
- [Trello Card #107](https://trello.com/c/dF0QIxv1/484-107-3-as-a-user-i-should-be-able-to-create-a-team-so-that-whoever-is-on-my-team-can-have-access-to-all-projects-assigned-to-team)

---
#### Description:
- The validation of uniqueness can't be done by rails validations because it is scoped to a particular association. In this case, the user can't create a team if it is already member of a team with that name.
  #### Risk:
- Medium

---
