### PR TITLE
Remove delete project btn for non autoriced users.

### DIFF
--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -17,10 +17,11 @@
             %span.icn-copy
         %li
           = react_component('SlackButton', {}, {prerender: false})
-        %li
-          = link_to current_project, method: :delete, data: { confirm: t('project.delete_confirmation') }, class: 'delete-project' do
-            = t('project.delete_project')
-            %span.icn-delete
+        - if current_user.id == current_project.owner_id
+          %li
+            = link_to current_project, method: :delete, data: { confirm: t('project.delete_confirmation') }, class: 'delete-project' do
+              = t('project.delete_project')
+              %span.icn-delete
   %ul.right.members
     - current_project.members.each_with_index do |member, index|
       - if index == 0


### PR DESCRIPTION
## Everyone is allowed to delete a project. Should only be owner.
#### Trello board reference:
- [Trello Card #479](https://trello.com/c/PlMFK3Pi/479-2-bug-everyone-is-allowed-to-delete-a-project-should-only-be-owner)

---
#### Description:
- 

---
#### Reviewers:

@vicocas @AlejandroFernandesAntunes 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
