### PR TITLE
Collapse icons for hide and show estimation boxes

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_dashboard.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_dashboard.js
@@ -78,15 +78,3 @@ function filterProjects(projects) {
     }
   });
 }
-
-function hideShowEstimation() {
-  var triggerHideShow = $('.estimation .title-breaker h5'),
-      estimationBoxes = $('.estimation-wrapper');
-  triggerHideShow.click(function () {
-    if (estimationBoxes.css('display') == 'none'){
-      estimationBoxes.fadeIn('slow');
-    } else {
-      estimationBoxes.fadeOut('slow');
-    }
-  });
-}

--- a/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
+++ b/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
@@ -5,3 +5,12 @@ function checkEstimation() {
     estimation.removeClass('hide');
   }
 }
+
+function hideShowEstimation() {
+  var triggerHideShow = $('.estimation .toggle-estimation'),
+      estimationBoxes = $('.estimation-wrapper');
+  triggerHideShow.click(function () {
+    estimationBoxes.fadeToggle();
+    $(this).toggleClass('active');
+  });
+}

--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -6,14 +6,41 @@ $estimation-margin: rem-calc(40);
 .estimation {
   .title-breaker h5:hover { cursor: pointer; }
 
+  .toggle-estimation,
   .icn-settings {
     background-color: $body-bg;
     color: $black-20;
     float: right;
-    line-height: rem-calc(24);
-    padding-left: rem-calc(10);
 
     &:hover { color: $black-30; }
+  }
+
+  .toggle-estimation {
+    @include border-radius(rem-calc(2));
+    border: 1px solid $black-20;
+    font-size: rem-calc(12);
+    height: rem-calc(15);
+    line-height: rem-calc(10);
+    margin-top: rem-calc(4);
+    text-align: center;
+    width: rem-calc(15);
+
+    &::before {
+      content: '+';
+      vertical-align: text-bottom;
+    }
+
+    &.active {
+      &::before {
+        content: '-';
+        vertical-align: middle;
+      }
+    }
+  }
+
+  .icn-settings {
+    line-height: rem-calc(24);
+    padding: rem-calc(0 7 0 15);
   }
 
   .estimation-wrapper {

--- a/app/views/arbor_reloaded/user_stories/_estimation.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation.haml
@@ -4,6 +4,7 @@
     (
     = total_points
     )
+  = link_to '', '#', class: 'has-tip toggle-estimation active', data: { tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.hide')
   = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
 .estimation-wrapper
   %ul.small-block-grid-1.large-block-grid-3

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,3 +311,4 @@ en:
       archive_story: 'Archive story'
       update_estimation: 'Settings'
       estimate: 'Estimate'
+      hide: 'Toggle Estimation'


### PR DESCRIPTION
## Add collapse option for hiding Estimation cards
#### Trello board reference:
- [Trello Card #626](https://trello.com/c/CWuF7t64/626-626-add-collapse-option-for-hiding-estimation-cards)

---
#### Reviewers:
- @mojo

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-02 at 5 46 28 p m](https://cloud.githubusercontent.com/assets/6147409/12763754/ec51f0a0-c9d4-11e5-9468-e357676e7c36.png)
