### PR TITLE
Add members icon position & tooltip

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_navigation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_navigation.scss
@@ -188,7 +188,7 @@ ul .dropdown {
       @include inline-block;
       background-size: cover;
       height: $member-avatar-dimension;
-      margin: (($sub-nav-height - $member-avatar-dimension) / 2) rem-calc(8) 0 0;
+      margin: (($sub-nav-height - $member-avatar-dimension) / 2) 0 0 rem-calc(8);
       width: $member-avatar-dimension;
 
       @media #{ $small-only } { display: none; }

--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -23,6 +23,10 @@
               = t('project.delete_project')
               %span.icn-delete
   %ul.right.members
+    %li
+      = link_to '+', |
+      arbor_reloaded_project_members_path(current_project), |
+      { class: 'add-member has-tip', data: { reveal_id: 'project-members-modal', reveal_ajax: true, tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.add_members') }
     - current_project.members.each_with_index do |member, index|
       - if index == 0
         %li
@@ -41,10 +45,6 @@
         = link_to arbor_reloaded_project_members_path(current_project),{ data: { reveal_id: 'project-members-modal', reveal_ajax: true }}, class: 'other-members' do
           +
           = current_project.members.count - 3
-    %li
-      = link_to '+', |
-      arbor_reloaded_project_members_path(current_project), |
-      { class: 'add-member', data: { reveal_id: 'project-members-modal', reveal_ajax: true } }
     -# TODO this link should only appear if the user is not a member of this project, and should't see the plus and members items, MOJO {remove .hidden-element for enable it}
     %li= link_to t('reloaded.project_dashboard.join_project'), '#', class: 'button radius success tiny join-btn hidden-element'
 #project-members-modal.reveal-modal{ data: { reveal: '' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,3 +320,4 @@ en:
       update_estimation: 'Settings'
       estimate: 'Estimate'
       hide: 'Toggle Estimation'
+      add_members: 'Add/Remove people'


### PR DESCRIPTION
## Move add members icon to left
#### Trello board reference:
- [Trello Card #640](https://trello.com/c/sFmyTxT8/640-640-move-add-members-icon-to-left)

---
#### Description:
- Change icon's position, add tooltip

---
#### Reviewers:
- @mojouy 

---
#### Preview:

![screen shot 2016-02-04 at 11 01 03 a m](https://cloud.githubusercontent.com/assets/6147409/12817038/9d4ef902-cb2e-11e5-9632-382fba153ce2.png)
