### PR TITLE
Estimation's modal update

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -1,4 +1,5 @@
 $estimation-margin: rem-calc(40);
+$icon-dimension: rem-calc(15);
 
 .estimation-wrapper h4,
 .edit-wrapper h4 { font-weight: normal; }
@@ -19,11 +20,11 @@ $estimation-margin: rem-calc(40);
     @include border-radius(rem-calc(2));
     border: 1px solid $black-20;
     font-size: rem-calc(12);
-    height: rem-calc(15);
+    height: $icon-dimension;
     line-height: rem-calc(10);
     margin-top: rem-calc(4);
     text-align: center;
-    width: rem-calc(15);
+    width: $icon-dimension;
 
     &::before {
       content: '+';
@@ -90,7 +91,9 @@ $estimation-margin: rem-calc(40);
   .estimation-item { text-align: center; }
 
   .title {
+    @include inline-block();
     font-size: rem-calc(12);
+    margin: 0;
     text-transform: uppercase;
   }
 
@@ -110,4 +113,17 @@ $estimation-margin: rem-calc(40);
       text-align: center;
     } // input
   } // edit wrapper
+
+  .estimation-info {
+    @include inline-block();
+    @include border-radius(100%);
+    border: 1px solid $black-20;
+    color: $black-20;
+    font-size: rem-calc(10);
+    font-weight: inherit;
+    height: $icon-dimension;
+    line-height: $icon-dimension;
+    text-align: center;
+    width: $icon-dimension;
+  }
 } // modal

--- a/app/views/arbor_reloaded/user_stories/_estimation_modal.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation_modal.haml
@@ -6,10 +6,12 @@
     .edit-wrapper.row
       .estimation-item.small-12.large-6.column
         %h4.title= t('reloaded.estimation.modal_velocity')
+        = link_to '?', '#', class: 'has-tip estimation-info', aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.estimation_velocity')
         = f.label :velocity, class: 'hide'
         = f.number_field :velocity, placeholder: project.velocity
       .estimation-item.small-12.large-6.column
         %h4.title= t('reloaded.estimation.modal_cost')
+        = link_to '?', '#', class: 'has-tip estimation-info', aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.estimation_cost')
         = f.label :cost_per_week, class: 'hide'
         = f.number_field :cost_per_week, placeholder: ''
     .modal-footer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,7 +229,7 @@ en:
       total_points: 'Total points'
       total_cost: 'Total cost'
       total_weeks: 'Weeks'
-      modal_title: 'Update Estimation Numbers'
+      modal_title: 'Estimation Settings'
       modal_velocity: 'Velocity'
       modal_cost: 'Cost per week'
     navigation:
@@ -321,3 +321,5 @@ en:
       estimate: 'Estimate'
       hide: 'Toggle Estimation'
       add_members: 'Add/Remove people'
+      estimation_velocity: 'This is an estimate of how many points your team can complete each week. You can use it to get a sense for how long development will take.'
+      estimation_cost: 'This is the cost of a sprint. Different development teams charge differently, but the average cost of a week of work is a good benchmark.'


### PR DESCRIPTION
## Copy & Tool Tip for Estimation Settings
#### Trello board reference:
- [Trello Card #625](https://trello.com/c/1ZAznNre/625-625-2-copy-tool-tip-for-estimation-settings)

---
#### Description:
- Update estimation modal's title, add icons with explanation tooltips.

---
#### Reviewers:
- @mojouy  @doshii 

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-04 at 6 17 14 p m](https://cloud.githubusercontent.com/assets/6147409/12829966/8c691572-cb6b-11e5-8b69-5e022c616691.png)
