### PR TITLE
Add error message styles to members modal.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_teams.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_teams.scss
@@ -29,8 +29,10 @@
 }//section people
 ////// Team modal
 
-#team-modal {
-  .team-name {
+#team-modal,
+#team-members-modal {
+  .team-name,
+  .team-member-email {
     font-size: rem-calc(14);
     margin: rem-calc(35) auto rem-calc(10);
     text-align: center;
@@ -38,9 +40,12 @@
     @include input-placeholder { font-size: rem-calc(14); }
 
     &.errors { border-color: $alert-color; }
+
+    &.team-member-email { margin: initial; }
   }//project name input
 
-  .new-team-errors {
+  .new-team-errors,
+  .team-member-errors {
     color: $alert-color;
     font-size: rem-calc(14);
     margin-bottom: rem-calc(30);

--- a/app/views/arbor_reloaded/teams/add_member.js.erb
+++ b/app/views/arbor_reloaded/teams/add_member.js.erb
@@ -1,4 +1,5 @@
 <% if @errors.count > 0 %>
+  $('.team-member-email').addClass('errors');
   $('.team-member-errors').html('*<%= @errors[0] %>');
 <% else %>
   $('.new-member-mail').val('');

--- a/app/views/arbor_reloaded/teams/partials/_invite_members.html.haml
+++ b/app/views/arbor_reloaded/teams/partials/_invite_members.html.haml
@@ -1,4 +1,4 @@
 = form_tag arbor_reloaded_team_add_member_path(team), method: :put, remote: true, class: 'new-member' do
-  = text_field_tag :member, nil, type: :email, placeholder: t('reloaded.project_members.mail_invite'), class: 'team-member-email'
+  = text_field_tag :member, nil, type: :email, placeholder: t('reloaded.project_members.mail_invite'), class: 'team-member-email radius'
   .team-member-errors
   = submit_tag :submit, class: 'submit-team-members hidden-element'


### PR DESCRIPTION
## Error message styles to members modal
#### Trello board reference:
- [Trello Card #108](https://trello.com/c/PyQot7td/492-108-3-as-a-team-owner-i-should-be-able-to-invite-users-to-my-team-so-that-i-can-add-all-the-users-that-need-to-be-on-my-team)

---
#### Description:
- Add styles to the email input on error and, to the error message itself .

---
#### Reviewers:
- @rosinanabazas @mojouy 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
