### PR TITLE
Add copy to error message.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,7 +217,7 @@ en:
       write_subtitle: 'On the field above, enter a user story to start filling up your project'
     team:
       no_email: 'Please type an email on the field to submit'
-      no_user: 'This email is not registered on Arbor'
+      no_user: 'Email is not registered on Arbor.'
       no_teams: "You don't have any teams yet. Create one by clicking on the plus sign."
       create: 'Create a Team'
       name: 'Enter new team name here...'


### PR DESCRIPTION
## Add copy changes on error messages.
#### Trello board reference:
- [Trello Card #108](https://trello.com/c/PyQot7td/492-108-3-as-a-team-owner-i-should-be-able-to-invite-users-to-my-team-so-that-i-can-add-all-the-users-that-need-to-be-on-my-team)

---
#### Description:
- 

---
#### Reviewers:
- @rosinanabazas 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
