### PR TITLE
Fix feedback on change password page

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -320,7 +320,6 @@ $block-animation-delay: .40s;
     background-color: transparent;
     border: 0;
     border-bottom: 1px dashed $black-20;
-    padding-bottom: $form-spacing;
     text-align: center;
 
     &:focus {

--- a/app/assets/stylesheets/arbor_reloaded/_user_session.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_user_session.scss
@@ -34,3 +34,5 @@
     padding: rem-calc(20);
   }
 } // usser session wrapper
+
+.change-password.row .button { margin-top: rem-calc(20); }

--- a/app/views/devise/registrations/edit.haml
+++ b/app/views/devise/registrations/edit.haml
@@ -3,8 +3,6 @@
     = render 'arbor_reloaded/navigation/user_nav'
   .change-password.row
     .small-12.medium-6.small-centered.columns.text-center
-      .title-breaker
-        %h5= t('reloaded.user_sessions.change_password')
       = form_for(resource, as: resource_name, url: registration_path(resource_name),
       html: { method: :put }) do |f|
         = devise_error_messages!


### PR DESCRIPTION
[#505] Feedback on change password page

Remove title
Add space between button and inputs,
fix issue in safari-firefox with inputs cutting off 

/cc @rosinanabazas 
## References
- https://trello.com/c/9jg6bdxl
## Risks

**Low.**

![screen shot 2016-02-09 at 12 57 25 pm](https://cloud.githubusercontent.com/assets/2197908/12921581/b4f22a32-cf2c-11e5-91f6-d4d6dda1ecb9.png)
