### PR TITLE
Change default root to be arbor reloaded

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,8 +5,8 @@ class RegistrationsController < Devise::RegistrationsController
 
   def after_sign_up_path_for(resource)
     create_template_project
-    if ENV['ENABLE_RELOADED'] == 'true'
-      arbor_reloaded_root_path
+    if ENV['ENABLE_RELOADED'] == 'false'
+      projects_path
     else
       super
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < Devise::SessionsController
   def after_sign_in_path_for(resource)
-    ENV['ENABLE_RELOADED'] == 'true' ? arbor_reloaded_root_path : super
+    ENV['ENABLE_RELOADED'] == 'false' ? projects_path : super
   end
 end

--- a/app/views/arbor_reloaded/projects/index.haml
+++ b/app/views/arbor_reloaded/projects/index.haml
@@ -11,7 +11,8 @@
       .no-projects
         %p.title= t('reloaded.project_dashboard.no_projects')
         %p= t('reloaded.project_dashboard.get_started')
-        = link_to t('reloaded.project_dashboard.create_button'), '#', class: 'button radius small', data: { reveal_id: 'project-modal' }
+        = link_to t('reloaded.project_dashboard.create_button'), '#', id: 'create-project-button',
+        class: 'button radius small', data: { reveal_id: 'project-modal' }
 
 #project-modal.reveal-modal{'aria-hidden' => 'true', 'aria-labelledby' => 'project-modal', 'data-reveal' => '', 'data-auto-reveal' => @new_project.errors.present?, :role => 'dialog' }
   = link_to '×', '#', class: 'close-reveal-modal'
@@ -27,4 +28,4 @@
       %h4= t('reloaded.create_project.team_title')
       = f.select(:team, options_for_select(current_user.teams.map(&:name).sort_by(&:downcase)), include_blank: '(none)')
     .action
-      = f.submit t('reloaded.create_project.save_button'), class: 'button radius tiny'
+      = f.submit t('reloaded.create_project.save_button'), class: 'button radius tiny', id: 'save-project'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Railsroot::Application.routes.draw do
   devise_scope :user do
     authenticated :user do
-      root to: 'projects#index', as: :authenticated_root
+      root to: 'arbor_reloaded/projects#index', as: :authenticated_root
     end
 
     unauthenticated :user do

--- a/spec/features/arbor_reloaded/landing_page/signup_and_login_spec.rb
+++ b/spec/features/arbor_reloaded/landing_page/signup_and_login_spec.rb
@@ -28,8 +28,8 @@ feature 'Sign up to Arbor' do
         end
       end
 
-      scenario 'should redirect me to arbor reloaded' do
-        expect(current_path).to eq('/arbor_reloaded')
+      scenario 'should redirect me to root' do
+        expect(current_path).to eq(root_path)
       end
 
       scenario 'should create a template project' do
@@ -50,7 +50,7 @@ feature 'Sign up to Arbor' do
       end
     end
 
-    scenario 'after log in should redirect me to arbor reloaded' do
+    scenario 'after log in should redirect me to root' do
       visit new_user_session_path
 
       within '#login' do
@@ -59,7 +59,7 @@ feature 'Sign up to Arbor' do
         find('#login_button').click()
       end
 
-      expect(current_path).to eq('/arbor_reloaded')
+      expect(current_path).to eq(root_path)
     end
   end
 
@@ -81,7 +81,7 @@ feature 'Sign up to Arbor' do
         click_button 'Sign up'
       end
 
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq('/projects')
     end
 
     scenario 'after log in should redirect me to old arbor' do
@@ -93,7 +93,7 @@ feature 'Sign up to Arbor' do
         find('#login_button').click()
       end
 
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq('/projects')
     end
   end
 end

--- a/spec/features/arbor_reloaded/project/log_spec.rb
+++ b/spec/features/arbor_reloaded/project/log_spec.rb
@@ -1,20 +1,21 @@
 require 'spec_helper'
 
-feature 'Log activity' do
+feature 'Log activity'do
   let!(:user) { create :user }
 
   background do
+    ENV['ENABLE_RELOADED'] = 'true'
     sign_in user
   end
 
   context 'for creating projects' do
     scenario 'should log project creation' do
       PublicActivity.with_tracking do
-        within '.content-general' do
-          click_link 'Create new project'
+        within '.projects-dashboard' do
+          find('#create-project-button').click
         end
         fill_in 'project_name', with: 'Test Project'
-        find('.create-project-btn').click
+        find('input#save-project').click
       end
 
       project_activities = Project.first.activities
@@ -24,10 +25,10 @@ feature 'Log activity' do
 
     scenario 'should not create logs when the save fails' do
       PublicActivity.with_tracking do
-        within '.content-general' do
-          click_link 'Create new project'
+        within '.projects-dashboard' do
+          find('.button').click
         end
-        find('.create-project-btn').click
+        find('input#save-project').click
       end
 
       expect(PublicActivity::Activity.all).to be_empty
@@ -56,11 +57,10 @@ feature 'Log activity' do
     end
 
     context 'user stories' do
-      let!(:hypothesis) { create :hypothesis, project: project }
       let(:user_story)  { build :user_story }
 
       background do
-        visit project_hypotheses_path project
+        visit project_user_stories_path project
       end
 
       scenario 'should log adding user stories' do

--- a/spec/features/landing_page/signup_spec.rb
+++ b/spec/features/landing_page/signup_spec.rb
@@ -6,6 +6,7 @@ feature 'Sign up to Arbor' do
 
   background do
     visit new_user_registration_path
+    ENV['ENABLE_RELOADED'] = 'true'
   end
 
   scenario 'should show me the minimum password length when I enter' do
@@ -21,7 +22,7 @@ feature 'Sign up to Arbor' do
 
       click_button 'Sign up'
     end
-    expect(page).to have_selector '#sidebar'
+    expect(current_path).to eq(root_path)
   end
 
   scenario 'should not show me the signup successful message' do

--- a/spec/features/project/display_project_for_members_spec.rb
+++ b/spec/features/project/display_project_for_members_spec.rb
@@ -7,7 +7,8 @@ feature 'Display projects only for members' do
   end
 
   scenario 'should show the project on sidebar' do
-    visit root_url
+    visit projects_path
+
     within 'aside' do
       expect(page).to have_text @project.name
     end
@@ -15,7 +16,8 @@ feature 'Display projects only for members' do
 
   scenario 'should not to show the project on sidebar' do
     project_not_member = create :project
-    visit root_url
+    visit projects_path
+
     within 'aside' do
       expect(page).not_to have_text project_not_member.name
     end

--- a/spec/features/project/log_spec.rb
+++ b/spec/features/project/log_spec.rb
@@ -5,6 +5,7 @@ feature 'Log activity' do
 
   background do
     sign_in user
+    visit projects_path
   end
 
   context 'for creating projects' do

--- a/spec/features/sidebar/structure_spec.rb
+++ b/spec/features/sidebar/structure_spec.rb
@@ -14,6 +14,7 @@ feature 'Sidebar structure changes' do
 
     background do
       sign_in user
+      visit projects_path
     end
 
     scenario 'the sidebar is displayed' do

--- a/spec/features/sidebar/version_spec.rb
+++ b/spec/features/sidebar/version_spec.rb
@@ -6,6 +6,7 @@ feature 'Check version string' do
   background do
     ENV['SIDEBAR_VERSION'] = 'MY_VERSION'
     sign_in user
+    visit projects_path
   end
 
   scenario 'sidebar version is displayed' do

--- a/spec/features/user/log_out_spec.rb
+++ b/spec/features/user/log_out_spec.rb
@@ -4,6 +4,7 @@ feature 'Sign in', js: true do
   context 'when the user logs in' do
     background do
       sign_in create :user
+      visit projects_path
     end
 
     scenario 'should show the logout button' do


### PR DESCRIPTION
## Make 'arbor_reloaded' arbor's default root view
#### Trello board reference:
- [Trello Card #667](https://trello.com/c/kjTVA18U/667-2-make-arbor-reloaded-arbor-s-default-root-view)

---
#### Description:
- Now the root url is arbor_reloaded. 
  Adapted the tests to new root url.
  Fix activity spec for arbor reloaded which was testing old arbor's feature.

---
#### Risk:
- Medium

---
