### PR TITLE
Add user story actions on user stories list

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -41,6 +41,10 @@ function generalBinds() {
     setFavoriteState();
     bindProjectsFilter();
   }
+  if ($('.backlog-story-list').length) {
+    displayActions();
+    displayHideDelete();
+  }
 }
 
 function bindAutoReveal() {

--- a/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
@@ -4,9 +4,11 @@ function displayActions() {
 
   $actionCaller.on( "click", function( event ) {
     $('.actions').removeClass('visible');
+    $('.icn-comments').addClass('hidden-element');
     $actionContainer = $(this).closest('li');
     $actionContainer.find($('.actions')).addClass('visible');
-    return false;
+    event.stopPropagation();
+    event.preventDefault();
   });
 
   $('html').click(function() {
@@ -17,11 +19,15 @@ function displayActions() {
     if ($('.deleter').hasClass('visible')) {
       $('.deleter').removeClass('visible');
     }
+
+    if ($('.icn-comments').hasClass('hidden-element')) {
+      $('.icn-comments').removeClass('hidden-element');
+    }
   });
 }
 
 function displayHideDelete() {
-  var $deleteCaller = $('.delete-project'),
+  var $deleteCaller = $('.delete-project, .delete-story'),
       $cancel       = $('.cancel');
   $deleteCaller.on( "click", function( event ) {
     $deleteContainer = $(this).closest('li');

--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -68,6 +68,17 @@ $circle-dimension: $story-points-dimension;
   padding: $story-padding-top $story-padding-sides;
   position: relative;
 
+  &.white-block .actions.actions { background-color: $transparent; }
+
+  .actions,
+  .deleter,
+  .right {
+    @include translateY(-50%);
+    position: absolute;
+    right: $block-padding;
+    top: 50%;
+  }
+
   &:first-child { margin-top: rem-calc(30); }
 
   &:hover {
@@ -78,10 +89,10 @@ $circle-dimension: $story-points-dimension;
   }//backlog user story hover
 
   .icn-comments {
+    bottom: 0;
     font-size: rem-calc(13);
-    right: $story-padding-sides;
-    top: $story-padding-top;
-    vertical-align: top;
+    margin-right: $story-padding-top / 2;
+    right: $story-padding-top;
 
     &:hover { @include opacity(.8); }
   } // comment icon

--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -123,8 +123,6 @@ $block-animation-delay: .40s;
     .right {
       line-height: $action-circle-dimension;
       position: absolute;
-      right: $block-padding + $block-grid-default-spacing / 2;
-      top: $block-padding;
       z-index: 2;
 
       [class^="icn-"] {
@@ -146,6 +144,8 @@ $block-animation-delay: .40s;
         }//other
       }//other and favorite
 
+      .delete-story,
+      .copy-story,
       .delete-project,
       .copy-project,
       [class^="icn-favorite"] {
@@ -168,7 +168,8 @@ $block-animation-delay: .40s;
       .icn-favorite-empty:hover,
       .is-favorite .icn-favorite-empty { &::before { content: '\e906'; } }//icon
 
-      .delete-project { margin-right: 0; }
+      .delete-project,
+      .delete-story { margin-right: 0; }
     }//all three floating sections on the right
 
     .actions,

--- a/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
@@ -180,7 +180,8 @@ $search-width: rem-calc(300);
   }//project link
 
   //projects not set as favorite
-  .common-projects-list {
+  .common-projects-list,
+  .team-projects-list {
     .actions,
     .deleter,
     .right {
@@ -190,6 +191,13 @@ $search-width: rem-calc(300);
       top: 50%;
     }
   }// regular project list
+
+  .actions,
+  .deleter,
+  .right {
+    right: $block-padding + $block-grid-default-spacing / 2;
+    top: $block-padding;
+  }
 
   // Favorite projects
   // - - - - - - - - - - - - - - - - -

--- a/app/views/arbor_reloaded/user_stories/_user_story.haml
+++ b/app/views/arbor_reloaded/user_stories/_user_story.haml
@@ -1,4 +1,4 @@
-%li.backlog-user-story{ data: { id: user_story.id } }
+%li.backlog-user-story.white-block{ data: { id: user_story.id } }
   %input.circle-checkbox{ id:"select-stories#{user_story.id}", type: 'checkbox', value: user_story.id }
   = link_to arbor_reloaded_user_story_path(user_story), class: 'story-detail-link', data: { reveal_id: 'story-detail-modal', reveal_ajax: 'true'} do
     %span.story-points
@@ -10,5 +10,20 @@
       %span= user_story.action
       %span.grey-prefix= t('reloaded.backlog.result')
       %span= user_story.result
+  .right
     = link_to '#', class: 'icn-comments hide' do
       %span.notification-badge
+    = link_to '#', class: 'others' do
+      &#149&#149&#149
+  .actions
+    %a.delete-story.has-tip{aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.delete_project')}
+      %span.icn-delete
+    = link_to '#', class: 'copy-story hidden-element has-tip', aria: { haspopup: true }, title: t('reloaded.tooltips.copy_project'), data: { tooltip: '' } do
+      %span.icn-copy
+  .deleter
+    %p
+      = t('reloaded.user_stories.actions.are_you_sure')
+      = link_to t('reloaded.user_stories.actions.confirm'), arbor_reloaded_user_story_path(user_story), method: :delete, class: 'button radius alert tiny'
+    %a.cancel= t('reloaded.user_stories.actions.cancel')
+    %a.delete-project
+      %span.icn-delete

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -6,7 +6,7 @@
 .estimation.row{class: @project.user_stories.count > 0 ? 'visible' : 'hide'}
   .small-12.columns
     = render 'arbor_reloaded/user_stories/estimation', project: @project, total_points: @total_points
-.backlog-story-list.row
+.backlog-story-list.white-blocks-list.row
   .sticky-menu
     = link_to '', '#', class: 'icn-copy has-tip tip-left', data: { reveal_id: 'copy-stories-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.copy_stories')
     = link_to '', '#', class: 'icn-archive has-tip tip-left', aria: { haspopup: true }, data: { tooltip: '' }, title: t('reloaded.tooltips.archive_stories')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,10 @@ en:
     user_stories:
       write_title: 'Write some User Stories'
       write_subtitle: 'On the field above, enter a user story to start filling up your project'
+      actions:
+        are_you_sure: 'Are you sure?'
+        confirm: 'Yes, delete it'
+        cancel: 'Cancel'
     team:
       no_email: 'Please type an email on the field to submit'
       no_user: 'Email is not registered on Arbor.'


### PR DESCRIPTION
## Add user story actions on Story list
#### Trello board reference:
- [Trello Card #569](https://trello.com/c/M11BZKYp/569-3-569-as-a-user-i-want-to-select-more-options-on-user-stories-so-that-i-can-delete-or-duplicate-it)

---
#### Description:
- As a User, I want to select more options on user stories so that I can delete or duplicate it

---
#### Reviewers:
- @mojo

---
#### Notes:
- Duplicate icon is hidden, the feature is not going to be made yet.

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-10 at 1 55 26 p m](https://cloud.githubusercontent.com/assets/6147409/12954847/09d6dd4a-cfff-11e5-965e-1308102a5feb.png)
![screen shot 2016-02-10 at 1 55 46 p m](https://cloud.githubusercontent.com/assets/6147409/12954848/0f68f036-cfff-11e5-9978-f9c8cf9af29b.png)
![screen shot 2016-02-10 at 1 55 49 p m](https://cloud.githubusercontent.com/assets/6147409/12954849/140f9aa4-cfff-11e5-8c3b-c2b33d36871d.png)
