### PR TITLE
Fix teams modal checkbox for deleting members broken after refactor

### DIFF
--- a/app/views/arbor_reloaded/teams/partials/_member_list.haml
+++ b/app/views/arbor_reloaded/teams/partials/_member_list.haml
@@ -26,4 +26,5 @@
             = member.full_name
           %p.user-mail
             = member.email
-          %input.circle-checkbox{ id:'remove-member-check', type: 'checkbox', class: 'hidden-element'  }
+          - if current_user == team.owner
+            %input.circle-checkbox{ class:'remove-member-check', type: 'checkbox', data:{ url: arbor_reloaded_team_remove_member_path(team, member: member.id) } }


### PR DESCRIPTION
## Fix checkbox on teams modal for deleting members
#### Trello board reference:
- [Trello Card #109](https://trello.com/c/dOkhn1wB/506-109-3-as-a-team-owner-i-should-be-able-to-remove-people-from-my-team-so-that-they-no-longer-have-access-to-team-projects)

---
#### Reviewers:
- @mojo
