### PR TITLE
Add team name to cover pdf page

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
@@ -5,13 +5,21 @@ body { background-color: $white; }
 
 .header-layout {
   height: 100%;
-  padding-top: rem-calc(300);
+  padding-top: rem-calc(270);
   text-align: center;
 
   h2 {
     color: $black-30;
 
     &.pdf-title { font-size: rem-calc(30); }
+
+    &.team-title {
+      bottom: 0;
+      font-size: rem-calc(20);
+      position: absolute;
+      text-align: center;
+      width: 100%;
+    }
 
     &.backlog-title {
       font-size: rem-calc(24);

--- a/app/controllers/arbor_reloaded/projects_controller.rb
+++ b/app/controllers/arbor_reloaded/projects_controller.rb
@@ -135,10 +135,13 @@ module ArborReloaded
 
     def export_content
       project_name = @project.name
+      project_team = @project.team
+      team_name = project_team.name if project_team
       cover_html =
         render_to_string(partial: 'arbor_reloaded/projects/pdf_cover.html.haml',
                          layout: 'pdf_cover_reloaded.pdf.haml',
-                         locals: { project_name: project_name })
+                         locals: { project_name: project_name,
+                                   team_name: team_name })
 
       send(:render_to_string,
            pdf: project_name,

--- a/app/views/arbor_reloaded/projects/_pdf_cover.html.haml
+++ b/app/views/arbor_reloaded/projects/_pdf_cover.html.haml
@@ -2,3 +2,6 @@
   %h2.pdf-title{ style: 'font-family: Helvetica, sans-serif;' }
     = project_name
   %h2.backlog-title Backlog
+  - if team_name
+    %h2.team-title
+      = team_name


### PR DESCRIPTION
## Add team name on PDF cover
#### Trello board reference:
- [Trello Card #445](https://trello.com/c/NdXwD6Uo/445-445-3-as-a-user-i-want-to-export-a-pdf-of-my-backlog-so-that-i-can-share-it)
#### Reviewers:
- @vico @mojo

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-12 at 4 44 40 p m](https://cloud.githubusercontent.com/assets/6147409/13018384/f3ef8d92-d1a7-11e5-98e5-3add91e539b6.png)
