### PR TITLE
Fix input file for firefox

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_profile.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_profile.scss
@@ -39,6 +39,8 @@ $profile-margin: $user-header-padding;
       width: $icon-dimension;
       z-index: 10;
 
+      &[type="file"] { @include opacity(0); }
+
       &:focus,
       &:active { outline: none; }
     } // edit

--- a/app/views/arbor_reloaded/users/show.html.haml
+++ b/app/views/arbor_reloaded/users/show.html.haml
@@ -5,6 +5,7 @@
 = form_for current_user, url: arbor_reloaded_user_path(current_user) do |f|
   .user-header
     .user-avatar
+      %span.icn-edit
       = f.file_field :avatar, class: 'icn-edit', id: 'edit-user-avatar-link'
       - if current_user.avatar?
         .avatar-img{ style: "background-image: url(#{ current_user.avatar_url });" }


### PR DESCRIPTION
[#531] Fix input file for firefox, since it doesn't support before pseudo elements on inputs

/cc @rosinanabazas 
## References
- https://trello.com/c/rQfLLyuC
## Risks

**Low.**

<img width="1552" alt="screen shot 2016-02-15 at 10 25 05 am" src="https://cloud.githubusercontent.com/assets/2197908/13049853/826cc0c6-d3ce-11e5-90bf-22a3ef4487c1.png">
