### PR TITLE
Fix deletion bug on teams.

### DIFF
--- a/app/controllers/arbor_reloaded/teams_controller.rb
+++ b/app/controllers/arbor_reloaded/teams_controller.rb
@@ -42,8 +42,7 @@ module ArborReloaded
     end
 
     def destroy
-      TeamUser.find_by(team: @team).destroy
-      unless @team.delete
+      unless @team.destroy
         flash[:alert] = I18n.t('reloaded.team.can_not_delete_team')
       end
       redirect_to :back

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,7 @@ class Team < ActiveRecord::Base
   validates_presence_of :name
   validates_presence_of :owner
 
-  has_many :team_users
+  has_many :team_users, dependent: :destroy
   has_many :users, through: :team_users
   belongs_to :owner, class_name: User
   has_many :projects

--- a/spec/features/arbor_reloaded/teams/delete_spec.rb
+++ b/spec/features/arbor_reloaded/teams/delete_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 
 feature 'Delete team', js: true do
   let!(:user) { create :user }
-  let!(:team) { create :team, users: [user], name: 'Awesome team', owner: user}
+  let!(:user2) { create :user }
+  let!(:team) { create :team, name: 'Awesome team', owner: user}
 
   background do
     sign_in user
+    team.users << user2
     visit arbor_reloaded_teams_path
   end
 


### PR DESCRIPTION
## Delete team a team owner
#### Trello board reference:
- [Trello Card #577](https://trello.com/c/U0wkrGEf/577-577-2-as-a-team-owner-i-want-to-delete-a-team-so-that-i-can-get-rid-of-it)

---
#### Description:
- Fixing a bug related to dependent destroy

---
#### Reviewers:
- @vicocas @AlejandroFernandesAntunes 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low
