### PR TITLE
Fix add member to project bug.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_members.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_members.js
@@ -26,7 +26,7 @@ $('#project-members-modal').on('opened.fndtn.reveal', function() {
       closeMembersModal();
     }
     if ($(this).text() == 'Invite') {
-      $('#submit-modal-form').click();
+      $('.submit-modal-form').click();
     }
   });
 });

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,6 +53,7 @@ class Project < ActiveRecord::Base
   end
 
   def add_member(user)
+    return if members.include?(user)
     create_activity :add_member,
       parameters: { element: user.log_description }
     members << user

--- a/app/services/arbor_reloaded/project_member_service.rb
+++ b/app/services/arbor_reloaded/project_member_service.rb
@@ -1,0 +1,40 @@
+module ArborReloaded
+  class ProjectMemberService
+    def initialize(project, current_user, email)
+      @project = project
+      @current_user = current_user
+      @inviter = current_user.full_name
+      @email = email
+    end
+
+    def invite_member
+      user = User.find_by(email: @email)
+      data = {
+        project_name: @project.name,
+        email:        @email,
+        inviter:      @inviter
+      }
+      if user
+        invite_user_to_project(user, data)
+      else
+        invite_new_user(data)
+      end
+    end
+
+    private
+
+    def invite_user_to_project(user, data)
+      return if @project.members.exists?(user.id)
+      InviteMailer.project_invite_email(data, false).deliver_now
+      @project.add_member(user)
+    end
+
+    def invite_new_user(data)
+      email = data[:email]
+
+      @project.invites <<
+        Invite.create(email: email) unless @project.invite_exists(email)
+      InviteMailer.project_invite_email(data, true).deliver_now
+    end
+  end
+end

--- a/app/views/arbor_reloaded/projects/partials/_invite_member.haml
+++ b/app/views/arbor_reloaded/projects/partials/_invite_member.haml
@@ -1,9 +1,3 @@
-= form_for project, url:  arbor_reloaded_project_path(project), html: { id: 'edit_project' }  do |f|
-  = f.text_field :name, class: 'hidden-element'
-  %input{ id: "member_#{project.members.count}", |
-    class: 'new-member-mail radius', |
-    name: "project[member_#{project.members.count}]", |
-    type: "email", |
-    required: true, |
-    placeholder: t('reloaded.project_members.mail_invite')}
-  = f.submit id: 'submit-modal-form', class: 'hidden-element'
+= form_tag arbor_reloaded_project_add_member_path(project), method: :put, class: 'edit_project' do
+  = text_field_tag :member, nil, type: :email, placeholder: t('reloaded.project_members.mail_invite'), class: 'new-member-mail radius'
+  = submit_tag :submit, class: 'submit-modal-form hidden-element'

--- a/app/views/arbor_reloaded/projects/partials/_projects_list.haml
+++ b/app/views/arbor_reloaded/projects/partials/_projects_list.haml
@@ -46,7 +46,7 @@
           - else
             %li.white-block.not-member
               .right
-                = link_to t('reloaded.project_dashboard.join_project'), arbor_reloaded_project_add_member_path(project), method: :put, class: 'button radius success tiny join-btn'
+                = link_to t('reloaded.project_dashboard.join_project'), arbor_reloaded_project_join_path(project), method: :put, class: 'button radius success tiny join-btn'
               .project.block-wrapper
                 .left
                   %p.title= project.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Railsroot::Application.routes.draw do
       end
 
       put 'add_member', controller: :projects, action: :add_member
+      put 'join', controller: :projects, action: :join_project
 
       get 'tags/filter', controller: :tags, action: :filter
       get 'tags/index', controller: :tags, action: :index


### PR DESCRIPTION
## Bug when adding members to a project
#### Trello board reference:
- [Trello Card #684](https://trello.com/c/dgmUFps8/684-project-members-modal-bug)

---
#### Description:
- Only the most recent member was left on the project members, the bug deleted all the other members. Refactored the adding members feature since it was copy&pasted from the old functionality which allowed adding several members at a time and didn't apply in this case.
