### PR TITLE
Hide Archive button on sticky menu

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -137,7 +137,7 @@ $circle-dimension: $story-points-dimension;
   @include border-radius($global-radius);
   background-color: $black-10;
   display: none;
-  height: ($story-points-dimension * 3) + ($icons-margin-bottom * 4);
+  height: ($story-points-dimension * 2) + ($icons-margin-bottom * 3);
   padding: $icons-margin-bottom;
   position: fixed;
   right: 5%;

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -6,7 +6,7 @@
 .backlog-story-list.white-blocks-list.row
   .sticky-menu
     = link_to '', '#', class: 'icn-copy has-tip tip-left', data: { reveal_id: 'copy-stories-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.copy_stories')
-    = link_to '', '#', class: 'icn-archive has-tip tip-left', aria: { haspopup: true }, data: { tooltip: '' }, title: t('reloaded.tooltips.archive_stories')
+    = link_to '', '#', class: 'icn-archive has-tip tip-left hidden-element', aria: { haspopup: true }, data: { tooltip: '' }, title: t('reloaded.tooltips.archive_stories')
     = link_to'', '#', class: 'icn-delete story-delete-link has-tip tip-left', data: { reveal_id: 'story-delete-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.delete_stories')
   .user-stories-container
     = render 'arbor_reloaded/user_stories/user_stories_list', project: @project


### PR DESCRIPTION
## Hide Archive button on user story sticky menu
#### Trello board reference:
- [Trello Card #682](https://trello.com/c/boZleWq7/682-1-682-feedback-hide-archive-story-button)

---
#### Description:
- Hide button as feature is not done at the moment.

---
#### Reviewers:
- @mojo

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-17 at 11 30 18 a m](https://cloud.githubusercontent.com/assets/6147409/13112542/d8f361c4-d569-11e5-88d2-9c853908b515.png)
