### PR TITLE
Delete members feature feedback

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_members.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_members.js
@@ -6,47 +6,64 @@ $('#project-members-modal').on('opened.fndtn.reveal', function() {
       editProjectForm   = $('.modal-edit-project-form'),
       footerButtonId = $('#people-modal-footer-btn');
       newMemberMailTextId = $('.new-member-mail'),
-      removeMemberFromProjectCheck = $('#remove-member-check'),
+      removeMemberCheck = $('.remove-member-check'),
       removeMemberFromProjectLink = $('.remove-member-link a'),
-      footerButtonInitialText = $(footerButtonId).text();
+      footerButtonInitialText = $(footerButtonId).text(),
+      membersToRemoveArray = [];
 
-  bindActionsOnRemovalCheckboxes();
+  bindAddMemberToRemove();
   customScroll();
 
   $(newMemberMailTextId).keyup(function(e) {
     if($(this).val() === '') {
       $(footerButtonId).text(footerButtonInitialText);
+      checkForSelectedMembers();
     } else {
       $(footerButtonId).text('Invite');
     }
   });
 
   $('#people-modal-footer-btn').click(function() {
-    if ($(this).text() == 'Close') {
-      closeMembersModal();
-    }
-    if ($(this).text() == 'Invite') {
-      $('.submit-modal-form').click();
-    }
-  });
-});
-
-//checkbox events on checked, Ale
-function bindActionsOnRemovalCheckboxes() {
-  removeMemberFromProjectCheck.click(function() {
-    if ($(this).is(':checked')) {
-      if ( confirm('Are you sure you want to remove the member?') ){
-        var url = $(this).data('url'),
-            type = 'DELETE',
-            currentObject = {};
-        ajaxCall(url,type,currentObject);
+    switch ($(this).text()) {
+      case 'Close':
         closeMembersModal();
-        alert('Member has been removed from project');
-      }
-      return false;
+        break;
+      case 'Invite':
+        $('.submit-modal-form').click();
+        break;
+      case 'Remove':
+        removeMembers(membersToRemoveArray);
+        break;
     }
   });
-}
+
+  function checkForSelectedMembers() {
+    if (removeMemberCheck.is(':checked')) {
+      $(footerButtonId).text('Remove');
+    } else {
+      $(footerButtonId).text('Close');
+    }
+  }
+
+  function bindAddMemberToRemove() {
+    removeMemberCheck.click(function() {
+      if ($(this).is(':checked')) {
+        membersToRemoveArray.push(this);
+      }
+      checkForSelectedMembers();
+    });
+  }
+
+  function removeMembers(members) {
+    $(members).each(function(index, el) {
+      var url = $(el).data('url'),
+          type = 'DELETE',
+          currentObject = {};
+      ajaxCall(url,type,currentObject);
+    });
+    closeMembersModal();
+  }
+});
 
 function closeMembersModal() {
   $('#project-members-modal').foundation('reveal', 'close');

--- a/app/views/arbor_reloaded/projects/members.html.haml
+++ b/app/views/arbor_reloaded/projects/members.html.haml
@@ -29,7 +29,7 @@
               = member.full_name
             %p.user-mail
               = member.email
-            %input.circle-checkbox{ id:'remove-member-check', type: 'checkbox', data:{ url: arbor_reloaded_project_remove_member_from_project_path(project, member: member.id)} }
+            %input.remove-member-check.circle-checkbox{ type: 'checkbox', data:{ url: arbor_reloaded_project_remove_member_from_project_path(project, member: member.id)} }
     - unless invites.empty?
       - invites.each do |invite|
         %li.user-item.invited

--- a/spec/features/arbor_reloaded/project/members_modal.rb
+++ b/spec/features/arbor_reloaded/project/members_modal.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+feature 'delete members on modal', js: true do
+  let!(:user)     { create :user }
+  let!(:user2)    { create :user }
+  let!(:project)  { create :project, owner: user, members: [user, user2] }
+
+  context 'when the user is on backlog' do
+    background do
+      sign_in user
+      visit arbor_reloaded_project_user_stories_path(project_id:project.id)
+      page.evaluate_script('$.fx.off = true;')
+      find('a.add-member').trigger('click')
+      sleep 1
+    end
+
+    scenario 'should show me the remove button when clicking the checkbox' do
+      within '.project-members' do
+        find('.remove-member-check').trigger('click')
+      end
+
+      within '.modal-footer' do
+        expect(page).to have_css('#people-modal-footer-btn', visible: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Correct delete feature behaviour on Members modal
#### Trello board reference:
- [Trello Card #673](https://trello.com/c/iFYLhdpH/673-2-673-feedback-correct-delete-members-feature-on-project-members-modal)

---
#### Description:
- When I select as many members as I want, the button that says Close changes to say “Remove”. Alert box no longer appears.

---
#### Risk:
- Medium

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/13177918/d9eec6b2-d6fa-11e5-92f1-a99b2d32aaf9.gif)
