### PR TITLE
Reduce storie's width when delete confirmation overlay is displayed

### DIFF
--- a/app/assets/javascripts/application-reloaded.js
+++ b/app/assets/javascripts/application-reloaded.js
@@ -29,6 +29,7 @@
 //= require arbor-reloaded/projects/copy_user_story_modal
 //= require arbor-reloaded/user_stories/delete_from_modal
 //= require arbor-reloaded/user_stories/estimation
+//= require arbor-reloaded/user_stories/stories_width
 //= require arbor-reloaded/user_profile/user_profile
 //= require arbor-reloaded/projects/actions/SlackModalActions
 //= require arbor-reloaded/projects/stores/SlackModalStore

--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -44,6 +44,7 @@ function generalBinds() {
   if ($('.backlog-story-list').length) {
     displayActions();
     displayHideDelete();
+    storiesWidth();
   }
 }
 

--- a/app/assets/javascripts/arbor-reloaded/user_stories/stories_width.js
+++ b/app/assets/javascripts/arbor-reloaded/user_stories/stories_width.js
@@ -1,0 +1,13 @@
+function storiesWidth() {
+  $('a.delete-story').on( "click", function() {
+    var storyId = $(this).data('id'),
+        storySelector = '#story-text-'+ storyId;
+    $(storySelector).addClass('shorten-story');
+  });
+
+  $('a.cancel').on( "click", function() {
+    var storyId = $(this).data('id'),
+        storySelector = '#story-text-'+ storyId;
+    $(storySelector).removeClass('shorten-story');
+  });
+}

--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -114,6 +114,8 @@ $circle-dimension: $story-points-dimension;
     padding: 0 ($story-points-dimension + $story-padding-sides);
   } // text
 
+  .shorten-story { width: 75%; }
+
   .circle-checkbox {
     @include opacity(0);
     background-color: $black-10;

--- a/app/views/arbor_reloaded/user_stories/_user_story.haml
+++ b/app/views/arbor_reloaded/user_stories/_user_story.haml
@@ -16,14 +16,14 @@
     = link_to '#', class: 'others' do
       &#149&#149&#149
   .actions
-    %a.delete-story.has-tip{aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.delete_project')}
+    %a.delete-story.has-tip{aria: {haspopup: true}, data: {id: user_story.id, tooltip: ''}, title: t('reloaded.tooltips.delete_project')}
       %span.icn-delete
     = link_to '#', class: 'copy-story hidden-element has-tip', aria: { haspopup: true }, title: t('reloaded.tooltips.copy_project'), data: { tooltip: '' } do
       %span.icn-copy
-  .deleter
+  .deleter{ id: "deleter-#{user_story.id}"}
     %p
       = t('reloaded.user_stories.actions.are_you_sure')
       = link_to t('reloaded.user_stories.actions.confirm'), arbor_reloaded_user_story_path(user_story), method: :delete, class: 'button radius alert tiny'
-    %a.cancel= t('reloaded.user_stories.actions.cancel')
+    %a.cancel{ data: { id: user_story.id } }= t('reloaded.user_stories.actions.cancel')
     %a.delete-project
       %span.icn-delete


### PR DESCRIPTION
## Reduce story width for when Delete confirmation overlay shows
#### Trello board reference:
- [Trello Card #688](https://trello.com/c/3Em1k9k4/688-2-if-the-story-is-too-long-the-delete-confirmation-overlaps-with-the-story-itself)

---
#### Reviewers:
- @doshi @mojo

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6147409/13259619/f4f8d6d4-da36-11e5-93b8-fb1bfe6302bc.gif)
