### PR TITLE
Fix Delete Project link on nav's dropdown

### DIFF
--- a/app/controllers/arbor_reloaded/projects_controller.rb
+++ b/app/controllers/arbor_reloaded/projects_controller.rb
@@ -50,7 +50,7 @@ module ArborReloaded
 
     def destroy
       @project.destroy
-      redirect_to :back
+      redirect_to arbor_reloaded_projects_path
     end
 
     def join_project

--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -42,7 +42,7 @@
           = react_component('SlackButton', {}, {prerender: false})
         - if current_user == current_project.owner
           %li
-            = link_to current_project, method: :delete, data: { confirm: t('project.delete_confirmation') }, class: 'delete-project' do
+            = link_to arbor_reloaded_project_path(current_project), method: :delete, data: { confirm: t('project.delete_confirmation') } do
               = t('project.delete_project')
               %span.icn-delete
   %ul.right.members

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -245,7 +245,6 @@ ActiveRecord::Schema.define(version: 20160219024519) do
     t.boolean  "admin",                  default: false
     t.string   "slack_id"
     t.string   "avatar"
-    t.string   "slack_auth_token"
     t.string   "trello_token"
   end
 

--- a/spec/features/arbor_reloaded/project/delete_spec.rb
+++ b/spec/features/arbor_reloaded/project/delete_spec.rb
@@ -12,7 +12,7 @@ feature 'delete project' do
     end
 
     scenario 'should show me the delete link' do
-      expect(page).to have_css('.delete-project')
+      expect(page).to have_css('.icn-delete')
     end
   end
 


### PR DESCRIPTION
## Fix Delete Project link on dropdown
#### Trello board reference:
- [Trello Card #689](https://trello.com/c/DwqWxCTZ/689-689-1-bug-delete-project-link-on-nav-leads-to-old-arbor-project-view)

---
#### Description:
- Delete Project link was incorrect, leading to old arbor.

---
#### Reviewers:
- @mojo

---
#### Risk:
- Low
