### PR TITLE
Fix typo on mail placeholder

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
   sign_up:
     title: "Sign up"
     name: "Full name"
-    mail: "EMail"
+    mail: "Email"
     password: "Password"
     password_confirmation: "Password confirmation"
     button_signup: "Sign up"


### PR DESCRIPTION
## Fix mail typo on sign up placeholder
#### Trello board reference:
- [Trello Card #706](https://trello.com/c/Nx4dDy6D/706-should-be-email-not-mail)

---
#### Reviewers:
- @damian
