### PR TITLE
Fix member's amount alignment

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_navigation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_navigation.scss
@@ -197,7 +197,6 @@ ul .dropdown {
         font-size: rem-calc(14);
         height: $user-edit-dimension;
         line-height: rem-calc(19);
-        margin-top: ($sub-nav-height - $user-edit-dimension) / 2;
         text-align: center;
         vertical-align: middle;
         width: $user-edit-dimension;
@@ -205,6 +204,7 @@ ul .dropdown {
         &.add-member {
           @include border-radius(100%);
           margin-right: 0;
+          margin-top: ($sub-nav-height - $user-edit-dimension) / 2;
         }
 
         &:hover { background-color: $black-20; }
@@ -216,6 +216,7 @@ ul .dropdown {
       }//add-member, other-members
 
       &.other-members {
+        @include border-radius(100%);
         background-color: transparent;
         border: 1px solid $black-30;
         color: $black-20;

--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -61,7 +61,7 @@
               .avatar-circle#avatar-circle= user_initial(member)
     - if current_project.members.count > 3
       %li
-        = link_to arbor_reloaded_project_members_path(current_project),{ data: { reveal_id: 'project-members-modal', reveal_ajax: true }}, class: 'other-members' do
+        = link_to arbor_reloaded_project_members_path(current_project), { class: 'other-members', data: { reveal_id: 'project-members-modal', reveal_ajax: true }} do
           +
           = current_project.members.count - 3
     -# TODO this link should only appear if the user is not a member of this project, and should't see the plus and members items, MOJO {remove .hidden-element for enable it}


### PR DESCRIPTION
## Fix nav's 'other members' number alignment
#### Trello board reference:
- [Trello Card #700](https://trello.com/c/HbVFl9m0/700-700-1-number-when-project-has-more-than-3-members-is-not-aligned)

---
#### Reviewers:
- @doshi

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-02-29 at 4 33 01 p m](https://cloud.githubusercontent.com/assets/6147409/13406417/1f67a3c6-df02-11e5-83b4-870f690edcdd.png)
