### PR TITLE
fix delete team

### DIFF
--- a/spec/controllers/arbor_reloaded/teams_controller_spec.rb
+++ b/spec/controllers/arbor_reloaded/teams_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe ArborReloaded::TeamsController do
   let(:user)         { create :user }
-  let(:team)         { create :team }
+  let(:team)         { create :team, owner: user }
   let(:another_user) { create :user }
 
   before :each do
@@ -23,6 +23,19 @@ RSpec.describe ArborReloaded::TeamsController do
       expect(created_team.users).to eq([user])
       expect(created_team.owner).to eq(user)
       expect(created_team.name).to eq('Team name')
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let!(:project) { create :project, team: team, owner: user }
+
+    it 'should destroy a team and not the projects' do
+      request.env['HTTP_REFERER'] = arbor_reloaded_teams_path
+
+      post(:destroy, id: team.id)
+
+      expect{ Team.find(team.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(project.owner).to eq(user)
     end
   end
 

--- a/spec/features/arbor_reloaded/teams/delete_spec.rb
+++ b/spec/features/arbor_reloaded/teams/delete_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 feature 'Delete team', js: true do
-  let!(:user) { create :user }
-  let!(:user2) { create :user }
-  let!(:team) { create :team, name: 'Awesome team', owner: user}
+  let!(:user)     { create :user }
+  let!(:user2)    { create :user }
+  let!(:team)     { create :team, name: 'Awesome team', owner: user }
+  let!(:project)  { create :project, team: team }
 
   background do
     sign_in user
@@ -24,5 +25,6 @@ feature 'Delete team', js: true do
 
     visit arbor_reloaded_teams_path
     expect(page).to_not have_content('Awesome team')
+    expect{ Team.find(team.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 end


### PR DESCRIPTION
## Fix delete team feature
#### Trello board reference:
- [Trello Card #683](https://trello.com/c/9RtsBpEU/683-2-bug-error-if-you-try-to-delete-a-team-with-projects-assigned-to-it)

---
#### Description:
- There was a foreign key constraint when trying to delete a team that had a project.

---
