### PR TITLE
Bug canvas redirect to arbor_reloaded

### DIFF
--- a/app/assets/javascripts/application-reloaded.js
+++ b/app/assets/javascripts/application-reloaded.js
@@ -22,6 +22,8 @@
 //= require arbor-reloaded/utils/vendor/jquery.mousewheel.min
 //= require arbor-reloaded/utils/vendor/jquery.mCustomScrollbar.concat.min
 //= require arbor-reloaded/utils/vendor/trello
+//= require arbor-reloaded/projects/canvas/canvas
+//= require arbor-reloaded/projects/canvas/form
 //= require arbor-reloaded/projects/project_actions
 //= require arbor-reloaded/projects/project_dashboard
 //= require arbor-reloaded/projects/project_members
@@ -34,8 +36,6 @@
 //= require arbor-reloaded/user_profile/user_profile
 //= require arbor-reloaded/projects/actions/SlackModalActions
 //= require arbor-reloaded/projects/stores/SlackModalStore
-//= require arbor-reloaded/utils/canvases/canvases
-//= require arbor-reloaded/utils/canvases/form
 //= require arbor-reloaded/utils/userStories/a_an_grammar
 //= require arbor-reloaded/utils/userStories/archive
 //= require arbor-reloaded/utils/userStories/copyModal

--- a/app/assets/javascripts/arbor-reloaded/projects/canvas/canvas.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/canvas/canvas.js
@@ -1,4 +1,4 @@
-function Canvases() {
+function Canvas() {
   var $canvasLinks       = $('li.canvas-item'),
       $canvasFields      = $('.canvas-fields'),
       $canvasTextarea    = $('.canvas-fields textarea'),

--- a/app/assets/javascripts/arbor-reloaded/projects/canvas/form.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/canvas/form.js
@@ -1,4 +1,4 @@
 $(document).ready(function() {
   new CustomTextArea();
-  new Canvases();
+  new Canvas();
 });

--- a/app/assets/javascripts/arbor-reloaded/utils/customTextArea.js
+++ b/app/assets/javascripts/arbor-reloaded/utils/customTextArea.js
@@ -18,14 +18,6 @@ function CustomTextArea() {
     }
   });
 
-  $('.resizable-text-area').focus(function(){
-    $('#save-canvas').show();
-  });
-
-  $('.resizable-text-area').blur(function(){
-    $('#save-canvas').hide();
-  });
-
   window.onresize = function() {
     $('.ui-sortable-handle .backlog-placeholder.resizable-text-area').each(function(index, currentValue) {
       var offset = currentValue.offsetHeight - currentValue.clientHeight;

--- a/app/controllers/arbor_reloaded/canvases_controller.rb
+++ b/app/controllers/arbor_reloaded/canvases_controller.rb
@@ -10,10 +10,6 @@ module ArborReloaded
 
     def create
       @canvas.update_attributes(canvas_params)
-      if env['HTTP_REFERER'].include? 'lab'
-        redirect_to :back
-        return
-      end
       render :index
     end
 

--- a/app/views/arbor_reloaded/canvases/_canvas_form.haml
+++ b/app/views/arbor_reloaded/canvases/_canvas_form.haml
@@ -1,5 +1,5 @@
 = hidden_field_tag 'require_canvas', id: 'require_canvas'
-= form_tag project_canvases_path(project), method: :post do
+= form_tag arbor_reloaded_project_canvases_path(project), method: :post do
   = hidden_field_tag 'current-question', current_question
   .problems-field.canvas-fields
     = label_tag :problems, t('problems_title')
@@ -39,4 +39,4 @@
     %p.enter press &#8629; to finish
   = submit_tag :save, class: 'button radius small secondary-btn', id: 'save-canvas'
 - content_for :custom_js do
-  = javascript_include_tag 'canvases/form'
+  = javascript_include_tag 'arbor-reloaded/projects/canvas/form'

--- a/app/views/arbor_reloaded/canvases/index.haml
+++ b/app/views/arbor_reloaded/canvases/index.haml
@@ -35,4 +35,5 @@
       type: 'cost-structure'}
         =t('cost_structure')
   .right-content-wrapper.large-6.columns
-    = render 'canvases/canvas_form', project: @project, canvas: @canvas, current_question: @current_question
+    = render 'arbor_reloaded/canvases/canvas_form',
+      project: @project, canvas: @canvas, current_question: @current_question

--- a/spec/controllers/arbor_reloaded/canvases_controller_spec.rb
+++ b/spec/controllers/arbor_reloaded/canvases_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ArborReloaded::CanvasesController do
+  describe 'GET index' do
+    let!(:project) { create :project }
+    let!(:canvas)  { create :canvas, project: project }
+
+    context 'for a non logged in user' do
+      it 'should redirect to login' do
+        get :index, { project_id: project.id }
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'for a logged in user' do
+      it 'should respond with 200' do
+        user = create :user
+        project.members.push(user)
+        sign_in user
+        get :index, { project_id: project.id }
+        expect(response).to be_success
+      end
+    end
+  end
+end

--- a/spec/features/arbor_reloaded/project/canvas/change_canvas_questions_spec.rb
+++ b/spec/features/arbor_reloaded/project/canvas/change_canvas_questions_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+feature 'Canvas question change for each canvas step' do
+  let!(:member)  { create :user }
+  let!(:project) { create :project, members: [member] }
+  let!(:canvas)  { create :canvas, project: project }
+
+  background do
+    sign_in member
+    visit arbor_reloaded_project_canvases_path(project)
+  end
+
+  scenario 'should stay on the answered question' do
+    find('.solutions-field textarea').set('My solution proposal')
+    find('#save-canvas', visible: false).click
+    within '.right-content-wrapper' do
+      expect(page).to have_text(I18n.t('solutions_title'))
+      expect(page).to have_text('My solution proposal')
+    end
+  end
+
+  scenario 'for problem step' do
+    find(".canvas-item[type='problems']").click()
+    question = 'What are the top three problems that you are trying to solve?'
+    expect(find('.problems-field label')).to have_content(question)
+  end
+
+  scenario 'for solutions step' do
+    find(".canvas-item[type='solutions']").click()
+    question = 'What are the top three features that solve your identified pain points or problems?'
+    expect(find('.solutions-field label')).to have_content(question)
+  end
+
+  scenario 'for alternative step' do
+    find(".canvas-item[type='alternative']").click()
+    question = 'How are users solving or overcoming these problems today, if at all?'
+    expect(find('.alternative-field label')).to have_content(question)
+  end
+
+  scenario 'for advantage step' do
+    find(".canvas-item[type='advantage']").click()
+    question = 'What about your solution can\'t be easily copied or bought.'
+    expect(find('.advantage-field label')).to have_content(question)
+  end
+
+  scenario 'for segment step' do
+    find(".canvas-item[type='segment']").click()
+    question = 'Who are your target customers?'
+    expect(find('.segment-field label')).to have_content(question)
+  end
+
+  scenario 'for channel step' do
+    find(".canvas-item[type='channel']").click()
+    question = 'What are your main path(s) to customers?'
+    expect(find('.channel-field label')).to have_content(question)
+  end
+
+  scenario 'for value proposition step' do
+    find(".canvas-item[type='value-proposition']").click()
+    question = 'Write a single, clear compelling message that states why you are different and worth taking notice of.'
+    expect(find('.value-proposition-field label')).to have_content(question)
+  end
+
+  scenario 'for revenue streams step' do
+    find(".canvas-item[type='revenue-streams']").click()
+    question = 'What is your revenue model, gross margin, and proposed path to revenue?'
+    expect(find('.revenue-streams-field label')).to have_content(question)
+  end
+
+  scenario 'for cost structure step' do
+    find(".canvas-item[type='cost-structure']").click()
+    question = 'What are your customer acquisition costs, distribution costs, people, hosting, integration partners, etc?'
+    expect(find('.cost-structure-field label')).to have_content(question)
+  end
+end

--- a/spec/features/arbor_reloaded/project/canvas/completed_percentage_spec.rb
+++ b/spec/features/arbor_reloaded/project/canvas/completed_percentage_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+feature 'Change complete percentage' do
+  let!(:member)  { create :user }
+  let!(:project) { create :project, owner: member }
+
+  scenario 'should be 80% for a canvas with 0 number of answered questions' do
+    create :canvas, :incomplete, { project: project }
+    sign_in member
+    visit arbor_reloaded_project_canvases_path(project)
+    expect(find('.percentage span')).to have_text('0%')
+  end
+
+  scenario 'should be 88% for a canvas with 8 number of answered questions' do
+    create :canvas, :without_problems, { project: project }
+    sign_in member
+    visit arbor_reloaded_project_canvases_path(project)
+    expect(find('.percentage span')).to have_text('88%')
+  end
+
+  scenario 'should show 100% percentage for a new canvas' do
+    create :canvas, { project: project }
+    sign_in member
+    visit arbor_reloaded_project_canvases_path(project)
+    expect(find('.percentage span')).to have_text('100%')
+  end
+
+  scenario 'should be 11% for a canvas with 1 number of answered questions' do
+    sign_in member
+    visit arbor_reloaded_project_canvases_path(project)
+    find('.problems-field textarea').set('My problem proposal')
+    find('#save-canvas', visible: false).click
+    expect(find('.percentage span')).to have_text('11%')
+  end
+end


### PR DESCRIPTION
## Redirect to arbor reloaded Canvas
#### Trello board reference:
- [Trello Card #645](https://trello.com/c/IvbYud5p/645-2-645-bug-canvas-redirecting-back-to-old-arbor-when-you-submit-something-new-in-a-field-let-s-make-sure-it-stays-in-arbor-reload)

---
#### Description:
- Adapt controller to arbor reloaded. Copy relevant tests from old arbor.

---
