### PR TITLE
Apply design update on Project Dashboard

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -369,3 +369,25 @@ $block-animation-delay: .40s;
 
   .button { display: inline; }
 }// empty teams, empty dashboard
+
+$circle-add-btn-dimension: rem-calc(55);
+
+.circle-add-btn {
+  @include border-radius(100%);
+  @include box-shadow($shadow-depth-1);
+  background-color: $success-color;
+  color: $white;
+  display: block;
+  font-size: rem-calc(25);
+  height: $circle-add-btn-dimension;
+  line-height: $circle-add-btn-dimension;
+  text-align: center;
+  vertical-align: middle;
+  width: $circle-add-btn-dimension;
+
+  &:hover,
+  &:focus {
+    @include opacity(.9);
+    color: $white;
+  }
+}

--- a/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
@@ -24,7 +24,6 @@ $search-width: rem-calc(300);
     input {
       background-color: $transparent;
       border: 0;
-      border-bottom: 1px solid $black-10;
       margin-bottom: 0;
       max-width: $search-width;
       padding-left: rem-calc(40);

--- a/app/views/arbor_reloaded/projects/partials/_projects_list.haml
+++ b/app/views/arbor_reloaded/projects/partials/_projects_list.haml
@@ -2,7 +2,7 @@
   - if projects.favorite.count > 0
     .title-breaker
       %h5= t('reloaded.project_dashboard.favorite', count: projects.favorite.count)
-    %ul.favorites.small-block-grid-1.medium-block-grid-3.large-block-grid-4
+    %ul.favorites.small-block-grid-1.medium-block-grid-3.large-block-grid-3
       - projects.favorite.each do |project|
         %li.favorite-project.white-block
           .right

--- a/app/views/arbor_reloaded/projects/partials/_search_bar.haml
+++ b/app/views/arbor_reloaded/projects/partials/_search_bar.haml
@@ -2,9 +2,9 @@
   .search-bar.small-12.medium-6.large-8.column
     %span.icn-search
     %input{ type: 'text', placeholder: t('reloaded.project_dashboard.search_input'), id: 'projects-filter', data: { url: arbor_reloaded_projects_list_path } }
-  .right-search-content.small-12.medium-6.large-4.column
+  .right-search-content.small-12.medium-6.large-3.column
     .recent-link
       = select_tag 'project_order', options_for_select({ t('reloaded.project_dashboard.sort_by_name')=>'by_name',
         t('reloaded.project_dashboard.sort_by_recent')=>'recent'}, 'recent'), data: { remote: true, url: arbor_reloaded_projects_path }
     .create-project
-      =link_to t('reloaded.project_dashboard.create_button'), '#', class: 'button radius small', id: 'create-project-btn', data: { reveal_id: 'project-modal' }
+      =link_to '+', '#', class: 'circle-add-btn', id: 'create-project-btn', data: { reveal_id: 'project-modal' }


### PR DESCRIPTION
## Apply design changes on Project Dashboard
#### Trello board reference:
- [Trello Card #709](https://trello.com/c/QNJMMlXu/709-709-apply-project-dashboard-s-visual-design-updates)

---
#### Reviewers:
- @doshii 

---
#### Tasks:
-  Replace Create project button with the new one '+'
- Apply new size to favorite cards and only display 3 per row
- Update searcher but still include the word Search in the field
#### Preview:

![screen shot 2016-03-04 at 3 45 36 p m](https://cloud.githubusercontent.com/assets/6147409/13536717/2ae8431a-e220-11e5-840d-471f76ac2e1a.png)
