### PR TITLE
Update trello scripts with https

### DIFF
--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -1,5 +1,5 @@
-%script{src: "http://code.jquery.com/jquery-1.7.1.min.js"}
-%script{src: "//api.trello.com/1/client.js?key=#{ENV['TRELLO_DEVELOPER_PUBLIC_KEY']}"}
+%script{ src: "http://code.jquery.com/jquery-1.7.1.min.js" }
+%script{ src: "https://api.trello.com/1/client.js?key=#{ENV['TRELLO_DEVELOPER_PUBLIC_KEY']}" }
 
 %nav.secondary-nav
   %ul.left

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20160302192522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "acceptance_criterions", force: :cascade do |t|
     t.text     "description"
@@ -245,8 +246,8 @@ ActiveRecord::Schema.define(version: 20160302192522) do
     t.boolean  "admin",                  default: false
     t.string   "slack_id"
     t.string   "avatar"
-    t.string   "trello_token"
     t.string   "slack_auth_token"
+    t.string   "trello_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/controllers/api_slack/slack_controller_spec.rb
+++ b/spec/controllers/api_slack/slack_controller_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe ApiSlack::SlackController do
   describe 'authorize' do
     it 'should redirect to the slack auth' do
       get :authorize, project_id: project.id
-      expected_url = "https://slack.com/oauth/authorize?scope=commands+incoming-webhook&client_id&redirect_uri=http%3A%2F%2Ftest.host%2Fapi_slack%2Fslack%2Fsend_authorize_data%3Fproject_id%3D#{project.id}"
+      expected_url = "https://slack.com/oauth/authorize?scope=commands+incoming-webhook&client_id=#{ENV['SLACK_CLIENT_ID']}&redirect_uri=http%3A%2F%2Ftest.host%2Fapi_slack%2Fslack%2Fsend_authorize_data%3Fproject_id%3D#{project.id}"
       expect(response).to redirect_to(expected_url)
     end
   end
 
   describe 'send_authorize_data' do
     it 'should redirect' do
-      get :send_authorize_data, code: '4750359453.21149128567.ac3a1c9bb8', project_id: project.id
+      get :send_authorize_data, code: 'VALID_CODE', project_id: project.id
       expect(response).to redirect_to(arbor_reloaded_project_user_stories_url(
         project, slack_status: 'success'))
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ Spork.prefork do
   ENV['TRELLO_DEVELOPER_PUBLIC_KEY'] = 'VALID_TRELLO_DEVELOPER_KEY'
   ENV['INTERCOM_APP_ID'] = 'VALID_INTERCOM_APP_ID'
   ENV['INTERCOM_API_KEY'] = 'VALID_INTERCOM_API_KEY'
+  ENV['SLACK_CLIENT_ID']='VALID_SLACK_CLIENT_ID'
+  ENV['SLACK_CLIENT_SECRET'] = 'CLIENT_SECRET'
 
   require File.expand_path('../../config/environment', __FILE__)
   require 'rspec/rails'

--- a/spec/vcr/slack/authorize.yml
+++ b/spec/vcr/slack/authorize.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://slack.com/api/oauth.access?client_id=4750359453.21034945302&client_secret=665b9889ce05d45840de858055446fc8&code=4750359453.21149128567.ac3a1c9bb8
+    uri: https://slack.com/api/oauth.access?client_id=VALID_SLACK_CLIENT_ID&client_secret=CLIENT_SECRET&code=VALID_CODE
     body:
       encoding: US-ASCII
       string: ''
@@ -50,6 +50,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"ok":true,"access_token":"xoxp-4750359453-4751795247-21146106389-a644feea9e","scope":"identify,commands,channels:read","team_name":"Neon
         Roots","team_id":"T04N2AKDB"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 12 Feb 2016 15:01:10 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
In order for the script of trello to work on secure connections we need to update the url to use https.

Fix slack related tests to not include real data. 
