### PR TITLE
Fix bug related to team owner

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,9 +62,16 @@ class Project < ActiveRecord::Base
     if selected_team_name.blank?
       self.owner = current_user
     else
-      self.team = current_user.teams.find_by(name: selected_team_name)
-      self.owner = team.owner
+      team = current_user.teams.find_by(name: selected_team_name)
+      self.team = team
+      assign_team_owner(team)
     end
+  end
+
+  def assign_team_owner(team)
+    team_owner = team.owner
+    self.owner = team_owner
+    add_member(team_owner)
   end
 
   def add_member(user)

--- a/spec/controllers/arbor_reloaded/projects_controller_spec.rb
+++ b/spec/controllers/arbor_reloaded/projects_controller_spec.rb
@@ -116,6 +116,18 @@ RSpec.describe ArborReloaded::ProjectsController do
       expect(project.owner).to eq(team.owner)
     end
 
+    it 'should add the team owner as member' do
+      allow_any_instance_of(ArborReloaded::IntercomServices)
+        .to receive(:create_event).and_return(true)
+
+      post :create, format: :html, project: { name: 'My project',
+          favorite: true, team: team.name }
+
+      project = Project.last
+      expect(project.owner).to eq(team.owner)
+      expect(project.members).to include(team.owner)
+    end
+
     it 'should create a new project without a team' do
       allow_any_instance_of(ArborReloaded::IntercomServices)
         .to receive(:create_event).and_return(true)


### PR DESCRIPTION
## Bug on project creation with teams
#### Trello board reference:
- [Trello Card #711](https://trello.com/c/Bs7JnIc3/711-2-bug-team-owner-is-the-owner-but-not-member-of-the-team-s-projects)

---
#### Description:
- When a project is created with a team, the team's owner becomes the project owner and a member of the project.

---
