### PR TITLE
format story & notifications fixes

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ ENABLE_COMMENTS=true
 SLACK_AUTH_URL=https://slack.com/oauth/authorize
 SLACK_ACCESS_URL=https://slack.com/api/oauth.access
 SLACK_DATA_URL=https://slack.com/api/auth.test
+SLACK_CONNECT_URL_NOTIFICATION=getarbor.io

--- a/app/controllers/api_slack/user_stories_controller.rb
+++ b/app/controllers/api_slack/user_stories_controller.rb
@@ -85,7 +85,8 @@ module ApiSlack
     def error_text(error)
       error = error.to_s
       if error == 'PROJECT_NOT_FOUND'
-        text = t('slack.notifications.no_configured_error', link: 'getarbor.io')
+        text = t('slack.notifications.no_configured_error',
+          link: ENV['SLACK_CONNECT_URL_NOTIFICATION'])
       elsif error == 'EMPTY'
         text = t('slack.notifications.empty_error')
       else

--- a/app/controllers/arbor_reloaded/user_stories_controller.rb
+++ b/app/controllers/arbor_reloaded/user_stories_controller.rb
@@ -30,7 +30,8 @@ module ArborReloaded
         story_services.new_user_story(user_story_params, current_user)
       return unless @project.slack_iw_url
       ArborReloaded::SlackIntegrationService.new(@project)
-        .user_story_notify(@user_story)
+        .user_story_notify(@user_story,
+          arbor_reloaded_project_user_stories_url(@project))
     end
 
     def update

--- a/spec/services/arbor_reloaded/slack_integration_service_spec.rb
+++ b/spec/services/arbor_reloaded/slack_integration_service_spec.rb
@@ -13,6 +13,218 @@ module ArborReloaded
       expect(user_story_created.role).to eq('Admin'.downcase)
       expect(user_story_created.action).to eq('to have privileges to all the database')
       expect(user_story_created.result).to eq('i can check the tables.')
+      expect(user_story_created.description).to be_nil
+    end
+
+    scenario 'should create a user story using another availables verbs' do
+      text = 'As an Admin I could have privileges to all the database so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to eq('Admin'.downcase)
+      expect(user_story_created.action).to eq('have privileges to all the database')
+      expect(user_story_created.result).to eq('i can check the tables.')
+      expect(user_story_created.description).to be_nil
+    end
+
+    scenario 'should create a user story using another availables verbs' do
+      text = 'As a Admin I should have privileges to all the database so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to eq('Admin'.downcase)
+      expect(user_story_created.action).to eq('have privileges to all the database')
+      expect(user_story_created.result).to eq('i can check the tables.')
+      expect(user_story_created.description).to be_nil
+    end
+
+    scenario 'should create a user story using another availables verbs' do
+      text = 'As an Admin I must have privileges to all the database so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to eq('Admin'.downcase)
+      expect(user_story_created.action).to eq('have privileges to all the database')
+      expect(user_story_created.result).to eq('i can check the tables.')
+      expect(user_story_created.description).to be_nil
+    end
+
+    scenario 'should create a user story with description when role is not given (normal format)' do
+      text = 'I want to have privileges to all the database so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when action is not given (normal format)' do
+      text = 'As an Admin so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when result is not given (normal format)' do
+      text = 'As an Admin I want to have privileges to all the database'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when role and result are not given (normal format)' do
+      text = 'I want to have privileges to all the database'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when role and action are not given (normal format)' do
+      text = 'so that I can check the tables'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when result and action are not given (normal format)' do
+      text = 'As an Admin'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+
+    scenario 'should create a user story with description when only label of role is given' do
+      text = 'As an I want to have privileges to all the database so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when only label of result is given' do
+      text = 'As an Admin I want to have privileges to all the database so'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when only label of action is given' do
+      text = 'As an Admin I want so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when only labels of role action are given' do
+      text = 'As an I want so that I can check the tables.'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when only labels are given' do
+      text = 'As an I want so that'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'should create a user story with description when anything else is given' do
+      text = 'Add slack integration to arbor'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+
+    scenario 'create user story with non resctricted format' do
+      text = 'aS     User   i   Should    Action   SO    Result'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to eq('user')
+      expect(user_story_created.action).to eq('action')
+      expect(user_story_created.result).to eq('result')
+      expect(user_story_created.description).to be_nil
+    end
+
+    scenario 'create user story with description when role, action and result are disordered' do
+      text = 'So that result as a user I want action'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'create user story with description when role, action and result are disordered' do
+      text = 'as a user So that result I want action'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
+    end
+
+    scenario 'create user story with description when role, action and result are disordered' do
+      text = 'as a user So that I want'
+      response = slack_integration_service.build_user_story(text, user)
+
+      user_story_created = UserStory.find(response.data[:user_story_id])
+      expect(user_story_created.role).to be_nil
+      expect(user_story_created.action).to be_nil
+      expect(user_story_created.result).to be_nil
+      expect(user_story_created.description).to eq(text.downcase)
     end
 
     scenario 'should do nothing with slack_enabled = false' do
@@ -21,7 +233,7 @@ module ArborReloaded
 
       response = slack_integration_service.build_user_story(text, user)
       user_story_created = UserStory.find(response.data[:user_story_id])
-      expect(slack_integration_service.user_story_notify(user_story_created)).to eq(nil)
+      expect(slack_integration_service.user_story_notify(user_story_created, 'link')).to eq(nil)
       expect(slack_integration_service.comment_notify(response.data[:user_story_id], 'comment')).to eq(nil)
     end
 
@@ -40,7 +252,7 @@ module ArborReloaded
       end
 
       VCR.use_cassette('slack/notifications') do
-        response = slack_integration_service.user_story_notify(user_story_created)
+        response = slack_integration_service.user_story_notify(user_story_created, 'link')
         expect(response.parsed_response).to eq("ok")
       end
     end


### PR DESCRIPTION
## Bug fixes
#### Trello board reference:
- [Trello Card #727](https://trello.com/c/VztzKn1p/727-as-a-slack-user-i-should-be-able-to-post-a-user-story-without-the-restricted-format)

---
#### Description:
- Change hardcoded URL into .env VAR
  Fix parse methods and test.

---
