### PR TITLE
Fix keyboard navigation on stories

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/user_story_modal.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/user_story_modal.js
@@ -44,17 +44,21 @@ function UserStory() {
 
   function NavigateUserStories() {
     $(document).unbind('keydown');
-    $(document).bind('keydown', function(e){
-      var $nextStory = $storyModal.find('.icn-arrow-right'),
-          $prevStory = $storyModal.find('.icn-arrow-left');
+    $(document).bind('keydown', function(e) {
+      var $inEditMode = $('#edit-mode').hasClass('active');
 
-      switch (e.which) {
-        case 37:
-          $prevStory.trigger('click');
-          break;
-        case 39:
-          $nextStory.trigger('click');
-          break;
+      if (!$inEditMode) {
+        var $nextStory = $storyModal.find('.icn-arrow-right'),
+            $prevStory = $storyModal.find('.icn-arrow-left');
+
+        switch (e.which) {
+          case 37:
+            $prevStory.trigger('click');
+            break;
+          case 39:
+            $nextStory.trigger('click');
+            break;
+        }
       }
     });
   }//navigate user stories

--- a/app/views/arbor_reloaded/user_stories/show.haml
+++ b/app/views/arbor_reloaded/user_stories/show.haml
@@ -34,7 +34,7 @@
     = link_to t('reloaded.project_dashboard.delete_project'), arbor_reloaded_user_story_path(@user_story), method: :delete, class: 'button radius alert tiny'
     = link_to t('reloaded.project_dashboard.cancel'), '#', class: 'cancel'
     %p.disclaimer= t('reloaded.story_modal.delete.disclaimer')
-  .edition-form
+  .edition-form#edit-mode
     = render 'arbor_reloaded/user_stories/edit_form', user_story: @user_story
 .modal-wrapper
   %section.acceptance-criteria.story-modal-section


### PR DESCRIPTION
#### Trello board reference:
- [Trello Card #732](https://trello.com/c/Mg8K4Ipa/732-bug-when-editing-a-story-if-using-the-keyboard-arrows-to-move-through-the-characters-it-changes-to-next-previous-story)

---
#### Description:
- Fixes BUG: When editing a story, if using the keyboard arrows to move through the characters, it changes to next/previous story

---
