### PR TITLE
Add env variable to control ssl enforce.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ssl_configured?
-    Rails.env.production?
+    Rails.env.production? && ENV['FORCE_SSL'] == 'true'
   end
 
   protected


### PR DESCRIPTION
We need to get rid of enfocre ssl for a while so we can generate a new certificate. This will allow us to not force people into ssl
