### PR TITLE
get rid of estimation totals on title.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -5,8 +5,6 @@ $icon-dimension: rem-calc(15);
 .edit-wrapper h4 { font-weight: normal; }
 
 .estimation {
-  .title-breaker h5:hover { cursor: pointer; }
-
   .toggle-estimation,
   .icn-settings {
     background-color: $body-bg;

--- a/app/views/arbor_reloaded/user_stories/_estimation.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation.haml
@@ -1,7 +1,6 @@
 .title-breaker
   %h5
     = t('reloaded.estimation.separator_title')
-    = "(#{total_points})"
   = link_to '', '#', class: 'has-tip toggle-estimation active', data: { tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.hide')
   = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
 .estimation-wrapper


### PR DESCRIPTION
## Get rid of the total value of the backlog in the Estimation title
#### Trello board reference:
- [Trello Card #744](https://trello.com/c/R3OGEfyO/744-get-rid-of-the-total-value-of-the-backlog-in-the-estimation-title)

---
#### Description:
- 

---
#### Reviewers:
- @mojouy @vicocas @pgonzaga2012 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
