### PR TITLE
Disable export button while exporting.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/utils/vendor/trello.js
+++ b/app/assets/javascripts/arbor-reloaded/utils/vendor/trello.js
@@ -61,6 +61,7 @@ function ajaxCallNewBoard(token, url) {
 }
 
 hideSuccessMessage();
+buttonDisable();
 
 function hideSuccessMessage() {
   var $trelloModal = $('#trello-modal');
@@ -79,5 +80,14 @@ function ajaxCallBoards(token, url) {
       $('.select-board-list').html(response);
       $('.select-board-list').removeClass('hide');
     }
+  });
+}
+
+function buttonDisable() {
+  $( document ).ajaxStart(function() {
+    $('#trello-export-submit').attr("disabled", true);
+  });
+  $(document).ajaxComplete(function () {
+    $('#trello-export-submit').attr("disabled", false);
   });
 }


### PR DESCRIPTION
## Hide the 'Export' button while exporting to prevent the user from triggering multiple exports.
#### Trello board reference:
- [Trello Card #726](https://trello.com/c/pUGaVeci/726-trello-export-hide-the-export-button-while-exporting-to-prevent-the-user-from-triggering-multiple-exports)

---
#### Description:
- 

---
#### Reviewers:
- @mojouy @vicocas @pgonzaga2012 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
