### PR TITLE
Unify a collapsable script for titles, and fix a bug in ui sortable styles being left after drag

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -112,3 +112,14 @@ function setVisibleState(elements, reversed){
     }
   });
 }
+
+function collapsableContent() {
+  var $trigger = $('.title-breaker .toggle-content-btn');
+
+  $trigger.click(function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $(this).parent().next().fadeToggle(400);
+    $(this).toggleClass('active');
+  });
+}

--- a/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_actions.js
@@ -48,5 +48,5 @@ function displayHideDelete() {
 $( document ).ready(function() {
   generalBinds();
   bindAutoReveal();
-  hideShowEstimation();
+  collapsableContent();
 });

--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -23,13 +23,14 @@ function bindReorderStories() {
   $reorder_stories.sortable({
     connectWith: '.reorder-user-stories',
     placeholder: 'sortable-placeholder',
-    over: function( event, ui ) {
+    over: function(event, ui) {
       $(event.target).addClass('active');
     },
-    out: function( event, ui ) {
+    out: function(event, ui) {
       $(event.target).removeClass('active');
     },
-    stop: function() {
+    stop: function(event, ui) {
+      $(ui.item).attr('style', '');
       var newStoriesOrder = setStoriesOrder(),
           url = $reorder_stories.data('url');
           project = $reorder_stories.data('project');

--- a/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
+++ b/app/assets/javascripts/arbor-reloaded/user_stories/estimation.js
@@ -5,12 +5,3 @@ function checkEstimation() {
     estimation.removeClass('hide');
   }
 }
-
-function hideShowEstimation() {
-  var triggerHideShow = $('.estimation .toggle-estimation'),
-      estimationBoxes = $('.estimation-wrapper');
-  triggerHideShow.click(function () {
-    estimationBoxes.fadeToggle();
-    $(this).toggleClass('active');
-  });
-}

--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -85,6 +85,8 @@ $circle-dimension: $story-points-dimension;
   } // span
 }//styles for backlog user story and modal
 
+.group-divider .title-breaker { cursor: pointer; }
+
 .reorder-user-stories {
   min-height: rem-calc(10);
 

--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -5,43 +5,6 @@ $icon-dimension: rem-calc(15);
 .edit-wrapper h4 { font-weight: normal; }
 
 .estimation {
-  .toggle-estimation,
-  .icn-settings {
-    background-color: $body-bg;
-    color: $black-20;
-    float: right;
-
-    &:hover { color: $black-30; }
-  }
-
-  .toggle-estimation {
-    @include border-radius(rem-calc(2));
-    border: 1px solid $black-20;
-    font-size: rem-calc(12);
-    height: $icon-dimension;
-    line-height: rem-calc(10);
-    margin-top: rem-calc(4);
-    text-align: center;
-    width: $icon-dimension;
-
-    &::before {
-      content: '+';
-      vertical-align: text-bottom;
-    }
-
-    &.active {
-      &::before {
-        content: '-';
-        vertical-align: middle;
-      }
-    }
-  }
-
-  .icn-settings {
-    line-height: rem-calc(24);
-    padding: rem-calc(0 7 0 15);
-  }
-
   .estimation-wrapper {
     margin: 0 auto;
 

--- a/app/assets/stylesheets/arbor_reloaded/_main.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_main.scss
@@ -117,6 +117,8 @@ input:focus {
 // -------  SECTION'S SEPARATOR ------ //
 
 .title-breaker {
+  $icon-dimension: rem-calc(15);
+
   margin: rem-calc(35) 0;
   position: relative;
   text-align: center;
@@ -146,6 +148,43 @@ input:focus {
 
   .reorder-user-stories {
     min-height: rem-calc(40);
+  }
+
+  .toggle-content-btn,
+  .icn-settings {
+    background-color: $body-bg;
+    color: $black-20;
+    float: right;
+
+    &:hover { color: $black-30; }
+  }
+
+  .toggle-content-btn {
+    @include border-radius(rem-calc(2));
+    border: 1px solid $black-20;
+    font-size: rem-calc(12);
+    height: $icon-dimension;
+    line-height: rem-calc(10);
+    margin-top: rem-calc(4);
+    text-align: center;
+    width: $icon-dimension;
+
+    &::before {
+      content: '+';
+      vertical-align: text-bottom;
+    }
+
+    &.active {
+      &::before {
+        content: '-';
+        vertical-align: middle;
+      }
+    }
+  }
+
+  .icn-settings {
+    line-height: rem-calc(24);
+    padding: rem-calc(0 7 0 15);
   }
 }//section separator
 

--- a/app/views/arbor_reloaded/groups/_list.haml
+++ b/app/views/arbor_reloaded/groups/_list.haml
@@ -4,6 +4,7 @@
       .group-divider{ id: "group-#{group.id}" }
         .title-breaker
           %h5= group.name
+          = link_to '', '#', class: 'has-tip toggle-content-btn active', data: { tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.hide')
         .reorder-user-stories{ data: { url: arbor_reloaded_project_reorder_backlog_path(project), project: project.id, group_id: group.id  } }
           - group.user_stories.backlog_ordered.each do |user_story|
             = render 'arbor_reloaded/user_stories/user_story', user_story: user_story

--- a/app/views/arbor_reloaded/user_stories/_estimation.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation.haml
@@ -1,6 +1,6 @@
 .title-breaker
   %h5= t('reloaded.estimation.separator_title')
-  = link_to '', '#', class: 'has-tip toggle-estimation active', data: { tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.hide')
+  = link_to '', '#', class: 'has-tip toggle-content-btn active', data: { tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.hide')
   = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
 .estimation-wrapper
   %ul.small-block-grid-1.large-block-grid-3


### PR DESCRIPTION
[#760] Make generic script for collapsing .title-breaker and next sibling
Also fixed a bug on styles that ui sortable was letting 

/cc @pgonzaga2012  @rosinanabazas 
## References
- https://trello.com/c/AU42R0Fu
## Risks

**Low.**

![screen shot 2016-06-23 at 10 04 35 am](https://cloud.githubusercontent.com/assets/2197908/16304049/1b79e06c-392a-11e6-88d3-c161d872872d.png)
![screen shot 2016-06-23 at 10 04 41 am](https://cloud.githubusercontent.com/assets/2197908/16304051/1b7ee1e8-392a-11e6-9043-3b6bf25d6316.png)
