### PR TITLE
Add "More" text on nav dropdown

### DIFF
--- a/app/views/arbor_reloaded/navigation/_secondary_nav.haml
+++ b/app/views/arbor_reloaded/navigation/_secondary_nav.haml
@@ -12,7 +12,7 @@
     %li.not-ready
       = link_to t('reloaded.navigation.assets'), arbor_reloaded_project_attachments_path(current_project), class: 'link'
     %li
-      = link_to '...', '#', aria: { controls: 'project-actions', expanded: false }, data: {dropdown: 'project-actions' }
+      = link_to t('reloaded.navigation.more'), '#', aria: { controls: 'project-actions', expanded: false }, data: {dropdown: 'project-actions' }
       %ul#project-actions.f-dropdown{ data: { dropdown: { content: '' } } }
         %li
           = link_to arbor_reloaded_project_export_backlog_path(current_project, format: :pdf, estimation: true) do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
       canvas: 'Canvas'
       backlog: 'Backlog'
       activity: 'Activity'
+      more: 'More...'
       assets: 'Assets'
       help: 'Help'
       export_with_estimation: 'Export as PDF'


### PR DESCRIPTION
## Add "More" text on nav dropdown
#### Trello board reference:
- [Trello Card #769](https://trello.com/c/H0iJKBgU/769-add-a-more-label-to-the-top-menu-item)

---
#### Description:
- Change top-nav's text from "..." to "More..."

---
#### Reviewers:
## \* @mojo
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-06-23 at 3 05 03 p m](https://cloud.githubusercontent.com/assets/6147409/16314389/e88b0206-3953-11e6-87e3-0c51282e6f0c.png)
