### PR TITLE
Make Estimation boards clickable

### DIFF
--- a/app/views/arbor_reloaded/user_stories/_estimation.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation.haml
@@ -6,22 +6,25 @@
   %ul.small-block-grid-1.large-block-grid-3
     %li
       #estimation-item-points.estimation-item.total-points
-        %h4.title= t('reloaded.estimation.total_points')
-        .value
-          %p.total_points= total_points
+        = link_to '#', data: { reveal_id: 'edit-estimation-modal' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation') do
+          %h4.title= t('reloaded.estimation.total_points')
+          .value
+            %p.total_points= total_points
         = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
-    %li
-      #estimation-item-cost.estimation-item
-        %h4.title= t('reloaded.estimation.total_cost')
-        .cost
-          %p.total_cost
-            = "$#{number_with_delimiter(project.total_cost)}"
-        = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
+      %li
+        #estimation-item-cost.estimation-item
+          = link_to '#', data: { reveal_id: 'edit-estimation-modal' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation') do
+            %h4.title= t('reloaded.estimation.total_cost')
+            .cost
+              %p.total_cost
+                = "$#{number_with_delimiter(project.total_cost)}"
+          = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
     %li
       #estimation-item-weeks.estimation-item
-        %h4.title= t('reloaded.estimation.total_weeks')
-        .value
-          %p.total_weeks
-            = project.total_weeks
+        = link_to '#', data: { reveal_id: 'edit-estimation-modal' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation') do
+          %h4.title= t('reloaded.estimation.total_weeks')
+          .value
+            %p.total_weeks
+              = project.total_weeks
         = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
 = render 'arbor_reloaded/user_stories/estimation_modal', project: project


### PR DESCRIPTION
## Make whole estimation boards clickable
#### Trello board reference:
- [Trello Card #768](https://trello.com/c/8KrhuBRf/768-768-make-the-whole-effort-cost-weeks-clickable-to-open-the-settings)

---
#### Reviewers:
- @mojo

---
