### PR TITLE
Reduce text size on Estimation cost PDF so it fits on the Board when budget has 8 digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pickle-email-*.html
 config/initializers/secret_token.rb
 config/secrets.yml
 .DS_Store
+Gemfile.lock
 
 ## Environment normalisation:
 /.bundle

--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -1,5 +1,6 @@
 $estimation-margin: rem-calc(40);
 $icon-dimension: rem-calc(15);
+$estimation-box-height: rem-calc(140);
 
 .estimation-wrapper h4,
 .edit-wrapper h4 { font-weight: normal; }
@@ -29,13 +30,13 @@ $icon-dimension: rem-calc(15);
       }
 
       .cost,
-      .value { height: rem-calc(140); }
+      .value { height: $estimation-box-height; }
 
       .value p { font-size: rem-calc(88); }
 
       .cost p {
-        @include translateY(50%);
-        font-size: rem-calc(40);
+        font-size: rem-calc(34);
+        line-height: $estimation-box-height;
       }
 
       .icn-settings {

--- a/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
@@ -40,6 +40,7 @@ body { background-color: $white; }
 }
 
 .backlog {
+  $estimation-box-height: rem-calc(140);
   height: 100%;
   margin: 0;
   max-width: 100%;
@@ -64,13 +65,13 @@ body { background-color: $white; }
     }
 
     .cost,
-    .value { height: rem-calc(140); }
+    .value { height: $estimation-box-height; }
 
     .value p { font-size: rem-calc(88); }
 
     .cost p {
-      @include translateY(50%);
-      font-size: rem-calc(40);
+      font-size: rem-calc(30);
+      line-height: $estimation-box-height;
     }
   } // item box
 


### PR DESCRIPTION
## Reduce text size on Estimation cost PDF so it fits on the Board
#### Trello board reference:
- [Trello Card #770](https://trello.com/c/660YkpiK/770-770-export-pdf-for-projects-with-budget-with-8-digits)

---
#### Description:
- Also reduce font on Backlog estimation.

---
#### Reviewers:
- @mojouy 

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-06-24 at 11 17 55 a m](https://cloud.githubusercontent.com/assets/6147409/16340352/20c08e20-39fe-11e6-8f68-7cb256d64cdb.png)
