### PR TITLE
Fix bug on bulk actions

### DIFF
--- a/app/views/arbor_reloaded/groups/create.js.erb
+++ b/app/views/arbor_reloaded/groups/create.js.erb
@@ -5,7 +5,7 @@
   $('.group-name').val('');
   $('#groups-list').empty().html("<%= j render 'arbor_reloaded/groups/list', groups: @groups, project: @project %>");
   $('#group-modal').foundation('reveal', 'close');
-  bindReorderStories();
+  backlogGeneralBinds();
 
   $.get(new_story_url, function(data) {
     $('#user-story-form-container').empty().html(data);


### PR DESCRIPTION
## Fix bug on bulk actions
#### Trello board reference:
- [Trello Card #763](https://trello.com/c/g5BIzHc3/763-763-bug-the-bulk-actions-are-not-binded-for-stories-added-to-a-group)

---
#### Reviewers:
- @doshii 

---
#### Tasks:

---
#### Risk:
- Low
