### PR TITLE
Make textareas taller

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_canvas.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_canvas.scss
@@ -59,7 +59,10 @@ $general-canvas-padding: rem-calc(30);
       margin-bottom: ($general-canvas-padding / 2);
     }
 
-    textarea { @include border-radius($global-radius); }
+    textarea {
+      @include border-radius($global-radius);
+      min-height: rem-calc(200);
+    }
   }
 
   .right-content-wrapper {


### PR DESCRIPTION
## 
#### Trello board reference:
- [Trello Card #766](https://trello.com/c/aw6MICWX/766-766-make-the-textarea-on-the-canvas-section-taller)

---
#### Description:
- Make Canvas textarea taller.

---
#### Reviewers:
- @doshii

---
#### Preview:

![screen shot 2016-06-27 at 12 34 44 p m](https://cloud.githubusercontent.com/assets/6147409/16385518/8d93ad5e-3c63-11e6-873f-db9aceea3770.png)
