### PR TITLE
Fix user story binds after create user story.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -148,4 +148,8 @@ function backlogGeneralBinds() {
   checkEstimation();
   collapsableContent();
   checkForEmptyGroupStories();
+  displayActions();
+  displayHideDelete();
+  displayColorTags();
+  bindUserStoriesColorLinks();
 }


### PR DESCRIPTION
## When you create a user story the three dots buttons not work
#### Trello board reference:
- [Trello Card #744](https://trello.com/c/aBhoZNYD/774-774-when-you-create-a-user-story-the-three-dots-buttons-not-work)

---
#### Description:
- 

---
#### Reviewers:
- @pgonzaga2012 @mojouy 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:
- N/A
