### PR TITLE
Fix safari color issue on projects.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_project_dashboard.scss
@@ -191,6 +191,7 @@ $search-width: rem-calc(300);
     .project {
       &::after {
         @include border-radius(0 0 $global-radius $global-radius);
+        @include inline-block();
         @include transition(height .25s ease-in);
         bottom: 0;
         content: '';
@@ -198,7 +199,7 @@ $search-width: rem-calc(300);
         left: 0;
         margin-top: rem-calc(10);
         position: absolute;
-        width: 100.5%;
+        width: 100%;
       } // project after
 
       .left { @include transition(margin-bottom .25s ease-in); }


### PR DESCRIPTION
## Frontend: Color strip coming up short on favorited cards on Safari.
#### Trello board reference:
- [Trello Card #722](https://trello.com/c/xRPqwQ2g/722-frontend-color-strip-coming-up-short-on-favorited-cards-on-safari)

---
#### Description:
- 

---
#### Reviewers:
- @rosinanabazas 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

<img width="683" alt="screen shot 2016-06-27 at 16 56 36" src="https://cloud.githubusercontent.com/assets/6106206/16393739/44df3f36-3c88-11e6-8789-e43459f0fba8.png">
