### PR TITLE
Reduce space between stories on PDF

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_pdf_export.scss
@@ -89,7 +89,6 @@ body { background-color: $white; }
       font-size: rem-calc(14);
       list-style: none;
       overflow: hidden;
-      padding-bottom: rem-calc(25);
 
       .description::before { content: '\2022'; }
     }
@@ -113,7 +112,6 @@ body { background-color: $white; }
 
     .user-story {
       font-size: rem-calc(16);
-      margin-bottom: rem-calc(10);
       padding-left: 0;
 
       .uppercase-subtitle {


### PR DESCRIPTION
## Reduce space between stories on PDF
#### Trello board reference:
- [Trello Card #724](https://trello.com/c/wqzOV3ce/724-724-frontend-excessive-space-between-user-stories-on-pdf-export)

---
#### Reviewers:
- @doshii 

---
#### Risk:
- Low

---
#### Preview:

![screen shot 2016-06-27 at 5 36 36 p m](https://cloud.githubusercontent.com/assets/6147409/16394876/bbf56262-3c8d-11e6-9d78-b0fe2480627a.png)
