### PR TITLE
Add preview image to avatar upload.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/user_profile/user_profile.js
+++ b/app/assets/javascripts/arbor-reloaded/user_profile/user_profile.js
@@ -1,12 +1,18 @@
-function copyArborToken() {
-  $('#copy-token').click(function(){
-    clipboard.copy($('#arbor-token-field').text());
-    return false;
-  });
-}
-
-$(document).ready(function(){
-  if ($('.section-profile').length) {
-    copyArborToken();
-  }
+$(document).on('click', '#copy-token', {}, function(event) {
+  clipboard.copy($('#arbor-token-field').text());
+  return false;
 });
+
+
+
+function readURL(input) {
+  if (input.files && input.files[0]) {
+    var reader = new FileReader();
+
+    reader.onload = function (e) {
+      $('#img_prev').css('background-image', 'url(' + e.target.result + ')');
+    };
+
+    reader.readAsDataURL(input.files[0]);
+  }
+}

--- a/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
+++ b/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
@@ -200,7 +200,8 @@ $shadow-depth-hover: rgba($black-50, .2) 3px 8px 25px;
   position: relative;
 
   .avatar-img,
-  .avatar-circle {
+  .avatar-circle,
+  .preview {
     @include background-size(cover);
     @include border-radius(100%);
     background-position: center;
@@ -210,6 +211,11 @@ $shadow-depth-hover: rgba($black-50, .2) 3px 8px 25px;
     text-align: center;
     width: $dimensions;
     z-index: 2;
+
+    &.preview {
+      position: absolute;
+      top: 0;
+    }
   }
 
   .avatar-circle {

--- a/app/views/arbor_reloaded/users/show.html.haml
+++ b/app/views/arbor_reloaded/users/show.html.haml
@@ -6,12 +6,13 @@
   .user-header
     .user-avatar
       %span.icn-edit
-      = f.file_field :avatar, class: 'icn-edit', id: 'edit-user-avatar-link'
+      = f.file_field :avatar, class: 'icn-edit', id: 'edit-user-avatar-link', onchange:'readURL(this);'
       - if current_user.avatar?
         .avatar-img{ style: "background-image: url(#{ current_user.avatar_url });" }
       - else
         = image_tag(current_user.gravatar_url, class: 'avatar-img', onerror: "this.src=''")
         .avatar-circle#avatar-circle= user_initial(current_user)
+      .avatar-img.preview#img_prev
 
     .field
       %h5.mail-title= t('reloaded.users.name')


### PR DESCRIPTION
## Create profile avatar preview when changing or uploading new picture.
#### Trello board reference:
- [Trello Card #787](https://trello.com/c/BrE4btVg/787-create-profile-avatar-preview-when-changing-or-uploading-new-picture)

---
#### Description:
- 

---
#### Reviewers:
- @pgonzaga2012 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

![out](https://cloud.githubusercontent.com/assets/6106206/16570082/39c4b3fa-4215-11e6-8238-5fd301adc2a4.gif)
