### PR TITLE
Replace logo image src for url on Error message

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -51,7 +51,7 @@
 <body>
   <!-- This file lives in public/404.html -->
   <div class="dialog">
-    <img src="arbor-logo.png" alt="Arbor logo">
+    <img src="https://s3.amazonaws.com/arbor2beta/arbor-logo.png" alt="Arbor logo">
     <h1>Ouch!</h1>
     <p>The page you are looking for does not exist, you may want to:</p>
   </div>

--- a/public/500.html
+++ b/public/500.html
@@ -51,7 +51,7 @@
 <body>
   <!-- This file lives in public/404.html -->
   <div class="dialog">
-    <img src="arbor-logo.png" alt="Arbor logo">
+    <img src="https://s3.amazonaws.com/arbor2beta/arbor-logo.png" alt="Arbor logo">
     <h1>Ouch!</h1>
     <p>The page you are looking for does not exist, you may want to:</p>
   </div>


### PR DESCRIPTION
## Error messages' logo image not displaying
#### Trello board reference:
- [Trello Card #786](https://trello.com/c/tlbcpz3S/786-786-error-page-not-displaying-images)

---
#### Description:
- Fix error logo image

---
#### Reviewers:
- @doshii 

---
#### Risk:
- Low
