### PR TITLE
Add tooltip on project create button.

### DIFF
--- a/app/views/arbor_reloaded/projects/partials/_search_bar.haml
+++ b/app/views/arbor_reloaded/projects/partials/_search_bar.haml
@@ -7,4 +7,4 @@
       = select_tag 'project_order', options_for_select({ t('reloaded.project_dashboard.sort_by_name')=>'by_name',
         t('reloaded.project_dashboard.sort_by_recent')=>'recent'}, 'recent'), data: { remote: true, url: arbor_reloaded_projects_path }
     .create-project
-      =link_to '+', '#', class: 'circle-add-btn', id: 'create-project-btn', data: { reveal_id: 'project-modal' }
+      =link_to '+', '#', class: 'circle-add-btn', id: 'create-project-btn', data: { reveal_id: 'project-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.create_project')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,6 +264,7 @@ en:
       copy_token: 'This is your token to connect Arbor with other apps'
       acceptance_criteria: 'Acceptance Criteria are statements that serve as conditions of satisfaction. They define the boundaries of a User Story and determine if a story is completed and working as intended.'
       delete_group: 'Delete group'
+      create_project: 'Create a new project'
     pdf:
       user_stories: 'User Stories'
     groups:


### PR DESCRIPTION
## Add a tooltip on the “Create a new project” button.
#### Trello board reference:
- [Trello Card #822](https://trello.com/c/cAXtkhOV/807-822-add-a-tooltip-on-the-create-a-new-project-button)

---
#### Description:
- 

---
#### Reviewers:
- @pgonzaga2012 @mojouy @oscarsiniscalchi 

---
#### Notes:
- 

---
#### Tasks:

---
#### Risk:
- Low

---
#### Preview:

<img width="983" alt="screen shot 2016-07-19 at 17 27 59" src="https://cloud.githubusercontent.com/assets/6106206/16965476/a64a1674-4dd6-11e6-8a7b-bce66f3f38ac.png">
