### PR TITLE
Add a new line in canvas form textareas with enter, and submit with command enter

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/canvas/canvas.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/canvas/canvas.js
@@ -1,5 +1,6 @@
 function Canvas() {
   var $canvasLinks       = $('li.canvas-item'),
+      $canvasForm        = $("#canvas form"),
       $canvasFields      = $('.canvas-fields'),
       $canvasTextarea    = $('.canvas-fields textarea'),
       $currentQuestion   = $('#current-question'),
@@ -39,5 +40,17 @@ function Canvas() {
 
   $canvasTextarea.bind('keyup', function() {
     setCurrentQuestion($(this).data('question'));
+  });
+
+  $canvasTextarea.unbind('keydown').bind('keydown', function(event) {
+    if (event.which == 13) {
+      if (event.metaKey) {
+        $canvasForm.submit();
+      } else {
+        var s = $(this).val();
+        $(this).val(s+"\n");
+        return false;
+      }
+    }
   });
 }

--- a/app/views/arbor_reloaded/canvases/_canvas_form.haml
+++ b/app/views/arbor_reloaded/canvases/_canvas_form.haml
@@ -4,39 +4,39 @@
   .problems-field.canvas-fields
     = label_tag :problems, t('problems_title')
     = text_area_tag :problems, canvas.problems, data: { question: 'problems' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .solutions-field.canvas-fields
     = label_tag :solutions, t('solutions_title')
     = text_area_tag :solutions, canvas.solutions, data: { question: 'solutions' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .alternative-field.canvas-fields
     = label_tag :alternative, t('alternative_title')
     = text_area_tag :alternative, canvas.alternative, data: { question: 'alternative' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .advantage-field.canvas-fields
     = label_tag :advantage, t('advantage_title')
     = text_area_tag :advantage, canvas.advantage, data: { question: 'advantage' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .segment-field.canvas-fields
     = label_tag :segment, t('segment_title')
     = text_area_tag :segment, canvas.segment, data: { question: 'segment' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .channel-field.canvas-fields
     = label_tag :channel, t('channel_title')
     = text_area_tag :channel, canvas.channel, data: { question: 'channel' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .value-proposition-field.canvas-fields
     = label_tag :value_proposition, t('value_proposition_title')
     = text_area_tag :value_proposition, canvas.value_proposition, data: { question: 'value-proposition' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .revenue-streams-field.canvas-fields
     = label_tag :revenue_streams, t('revenue_streams_title')
     = text_area_tag :revenue_streams, canvas.revenue_streams, data: { question: 'revenue-streams' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   .cost-structure-field.canvas-fields
     = label_tag :cost_structure, t('cost_structure_title')
     = text_area_tag :cost_structure, canvas.cost_structure, data: { question: 'cost-structure' }, class: 'resizable-text-area', placeholder: t('canvas.textarea_placeholder')
-    %p.enter press &#8629; to finish
+    %p.enter press &#8984;&#8629; to finish
   = submit_tag :save, class: 'button radius tiny secondary-btn', id: 'save-canvas'
 - content_for :custom_js do
   = javascript_include_tag 'arbor-reloaded/projects/canvas/form'


### PR DESCRIPTION
## Submitting Canvas textareas

#### Trello board reference:

* [Trello Card #788](https://trello.com/c/3gmIEmYr/788-on-canvas-when-i-press-enter-it-should-add-an-empty-line-instead-of-submitting-the-form)

---

#### Description:

* Add a new line in canvas form textareas with enter, and submit with command enter

---

#### Tasks:

  - [x] Set keydown event to text areas to check if cmd + enter is being pressed

  - [x] Change the label to show press ⌘↵ to finish

