### PR TITLE
Fix on original project.

### DIFF
--- a/db/migrate/20170116205844_fix_backlog_order_default_project.rb
+++ b/db/migrate/20170116205844_fix_backlog_order_default_project.rb
@@ -1,0 +1,18 @@
+class FixBacklogOrderDefaultProject < ActiveRecord::Migration
+  class UserStory < ActiveRecord::Base
+  end
+
+  class Project < ActiveRecord::Base
+    has_many :user_stories
+  end
+
+  def change
+    project = Project.where(name: 'Taxi Hailing App').first
+
+    if project
+      project.user_stories.order(:id).each_with_index do |story, index|
+        story.update_column(:backlog_order, index + 1)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161230155444) do
+ActiveRecord::Schema.define(version: 20170116205844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -191,12 +191,13 @@ Project.find_or_initialize_by(is_template: true) do |project|
   story.acceptance_criterions << AcceptanceCriterion
     .new(description: 'Verify that luxury tier is available anywhere when I need it')
 
-  stories_array.each do |story|
+  stories_array.each_with_index do |story, index|
     new_story = UserStory.new(
       role: story[:role],
       action: story[:action],
       result: story[:result],
-      estimated_points: story[:estimated_points])
+      estimated_points: story[:estimated_points],
+      backlog_order: index + 1)
     project.user_stories << new_story
   end
 


### PR DESCRIPTION
## Try to copy Taxi Hailing App project, result on an application error and it gets copied 2 times

#### Trello board reference:

* [Trello Card #823](https://trello.com/c/B6Wh3xqT/823-823-try-to-copy-taxi-hailing-app-project-result-on-an-application-error-and-it-gets-copied-2-times)

---

#### Description:

* Example project was outdated regarding changes made as the Arbor project grew. Some information was missing, in this case `backlog_order` for each story, so you were not able to copy the project. Also, when a new user was created, and this project was copied as an example, an error occurred.

---

#### Notes:

* There are many projects with the same name (at least one per user, plus the original one), so we want the first, that's why the use of `where().first` and not `find_by`.
```ruby
project = Project.where(name: 'Taxi Hailing App').first
```
*
```ruby
stories_array.each_with_index do |story, index|
    new_story = UserStory.new(
      ...
      backlog_order: index + 1)
    ...
end
```
Order is set as 1 by the callback, because of an extra scope added. 
Another solution could be to change `app/models/user_story.rb:76` to: 
```ruby
def order_in_backlog
  self.backlog_order = project.user_stories.unscoped.maximum(:backlog_order).to_i + 1
end
```
But since this code is working for all the other cases, we thought it would be best to fix the seed.

---

#### Tasks:

  - [x] Fix seed so stories have a `backlog_order` predefined.

  - [x] Added migration to fix current base project on production.


---

#### Risk:

* Low