### PR TITLE
Story/884/estimation settings desing update

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_estimation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_estimation.scss
@@ -38,16 +38,6 @@ $estimation-box-height: rem-calc(140);
         font-size: rem-calc(34);
         line-height: $estimation-box-height;
       }
-
-      .icn-settings {
-        background-color: transparent;
-        bottom: rem-calc(5);
-        display: none;
-        position: absolute;
-        right: rem-calc(5);
-      }//.icn-settings
-
-      &:hover { .icn-settings { display: block; } }
     } // item box
   }
 } // estimation
@@ -56,12 +46,16 @@ $estimation-box-height: rem-calc(140);
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
 #edit-estimation-modal {
-  padding: 0;
   text-align: center;
   width: rem-calc(400);
 
-  h5 { border-bottom: 1px solid $black-20;}
-  .estimation-item { text-align: center; }
+  h5 { background-color: $light-bg; }
+
+  .estimation-item {
+    text-align: center;
+
+    + .estimation-item { margin-top: rem-calc(30); }
+  }
 
   .title {
     @include inline-block();
@@ -77,7 +71,9 @@ $estimation-box-height: rem-calc(140);
     input {
       background-color: $light-bg;
       border: 0;
+      border-bottom: 1px solid $black-20;
       color: $black;
+      display: block;
       font-size: rem-calc(40);
       height: rem-calc(50);
       line-height: rem-calc(50);
@@ -99,4 +95,6 @@ $estimation-box-height: rem-calc(140);
     text-align: center;
     width: $icon-dimension;
   }
+
+  .modal-footer { border-top: 0; }
 } // modal

--- a/app/views/arbor_reloaded/user_stories/_estimation.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation.haml
@@ -10,7 +10,6 @@
           %h4.title= t('reloaded.estimation.total_points')
           .value
             %p.total_points= total_points
-        = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
       %li
         #estimation-item-cost.estimation-item
           = link_to '#', data: { reveal_id: 'edit-estimation-modal' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation') do
@@ -18,7 +17,6 @@
             .cost
               %p.total_cost
                 = "$#{number_with_delimiter(project.total_cost)}"
-          = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
     %li
       #estimation-item-weeks.estimation-item
         = link_to '#', data: { reveal_id: 'edit-estimation-modal' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation') do
@@ -26,5 +24,4 @@
           .value
             %p.total_weeks
               = project.total_weeks
-        = link_to '', '#', class: 'icn-settings has-tip', data: { reveal_id: 'edit-estimation-modal', tooltip: '' }, aria: { haspopup: true }, title: t('reloaded.tooltips.update_estimation')
 = render 'arbor_reloaded/user_stories/estimation_modal', project: project

--- a/app/views/arbor_reloaded/user_stories/_estimation_modal.haml
+++ b/app/views/arbor_reloaded/user_stories/_estimation_modal.haml
@@ -4,12 +4,12 @@
     %h5= t('reloaded.estimation.modal_title')
   = form_for project, url: arbor_reloaded_project_path(project), html: { id: 'edit-project', novalidate: '' } do |f|
     .edit-wrapper.row
-      .estimation-item.small-12.large-6.column
+      .estimation-item
         %h4.title= t('reloaded.estimation.modal_velocity')
         = link_to '?', '#', class: 'has-tip estimation-info', aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.estimation_velocity')
         = f.label :velocity, class: 'hide'
         = f.number_field :velocity, min: 0, placeholder: t('project.default.velocity')
-      .estimation-item.small-12.large-6.column
+      .estimation-item
         %h4.title= t('reloaded.estimation.modal_cost')
         = link_to '?', '#', class: 'has-tip estimation-info', aria: {haspopup: true}, data: {tooltip: ''}, title: t('reloaded.tooltips.estimation_cost')
         = f.label :cost_per_week, class: 'hide'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,8 +173,8 @@ en:
       total_cost: 'Total estimated cost'
       total_weeks: 'Effort in weeks'
       modal_title: 'Estimation Settings'
-      modal_velocity: 'Velocity'
-      modal_cost: 'Cost per week'
+      modal_velocity: 'Velocity per sprint'
+      modal_cost: 'Cost per sprint'
     navigation:
       menu: 'Menu'
       projects: 'Projects'

--- a/spec/features/arbor_reloaded/project/backlog_spec.rb
+++ b/spec/features/arbor_reloaded/project/backlog_spec.rb
@@ -13,11 +13,8 @@ def set_project_velocity(velocity)
 end
 
 def set_cost_input
-  within '#estimation-item-cost' do
-    find('.icn-settings', visible: false).trigger(:click)
-    sleep 0.5
-  end
-
+  find('#estimation-item-cost').click()
+  sleep 0.5
   yield
   click_button 'Save Changes'
   wait_for_ajax

--- a/spec/features/arbor_reloaded/user_stories/estimation_spec.rb
+++ b/spec/features/arbor_reloaded/user_stories/estimation_spec.rb
@@ -49,11 +49,8 @@ feature 'Estimation totals', js:true do
     end
   end
 
-  scenario 'I sould access to estimation settings from extimation boxes' do
-    within '.total-points' do
-      find('.icn-settings', visible: false).trigger('click')
-    end
-
+  scenario 'I sould access to estimation settings from estimation boxes' do
+    find('.total-points').click()
     expect(page).to have_content('Estimation Settings')
   end
 end


### PR DESCRIPTION
## Estimation Settings Overlay Design Update

#### Trello board reference:

* [Trello Card #884](https://trello.com/c/Q4e950Yt/884-estimation-settings-overlay-design-update)

---

#### Description:

* Estimation modal style updated.

---

#### Tasks:

  - [x] Update style.

  - [x] Remove settings icon from estimations' rows.


---

#### Risk:

* Low

---

#### Preview:
<img width="1265" alt="screen shot 2017-01-19 at 4 48 31 pm" src="https://cloud.githubusercontent.com/assets/5388243/22122550/276db618-de67-11e6-9372-9a7bee60a71f.png">

