### PR TITLE
New design implemented for new stories on backlog.

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -171,6 +171,41 @@ function refreshProjectEstimations(total_points, total_cost, total_weeks) {
   $('.total_weeks').text(total_weeks);
 }
 
+function onNewBacklogStoryInputKeyup() {
+  var $backlogStoryInput = $('.backlog-story-input input'),
+      $saveStoryButton   = $('#save-user-story');
+
+  $backlogStoryInput.keyup(function() {
+    var count = $backlogStoryInput.filter(function() {
+      return $(this).val().length > 0;
+    }).length;
+
+    if (count === $backlogStoryInput.length) {
+      $saveStoryButton.addClass('complete');
+    } else {
+      $saveStoryButton.removeClass('complete');
+    }
+  })
+}
+
+function fixNewBacklogStoryOnTop() {
+  var $newBacklogStory        = $('.new-backlog-story'),
+      $userStoryFormContainer = $('#user-story-form-container');
+
+  if ($(window).scrollTop() >= $newBacklogStory.offset().top) {
+    $userStoryFormContainer.addClass('fixed');
+  } else {
+    $userStoryFormContainer.removeClass('fixed');
+  }
+}
+
+function fixNewBacklogStoryHeight() {
+    var $newBacklogStory        = $('.new-backlog-story'),
+        $userStoryFormContainer = $('#user-story-form-container');
+
+    $newBacklogStory.height($userStoryFormContainer.outerHeight());
+}
+
 $(document).ready(function() {
   if ($('.new-backlog-story').length > 0) { autogrowInputs(); }
 
@@ -180,6 +215,14 @@ $(document).ready(function() {
     checkForEmptyGroupStories();
     bindUserStoriesColorLinks();
     toggleGroupForm();
+  }
+
+  if ($('.new-backlog-story').length > 0) {
+    onNewBacklogStoryInputKeyup();
+    fixNewBacklogStoryHeight();
+    $(window)
+      .scroll(fixNewBacklogStoryOnTop)
+      .resize(fixNewBacklogStoryHeight);
   }
 });
 

--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -2,18 +2,32 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
 .new-backlog-story {
-  @include border-radius($global-radius);
-  border-bottom: 2px dashed $black-20;
-  color: $black-40;
-  font-size: rem-calc(22);
-  padding: rem-calc(15 25);
-  position: relative;
+  $story-font-size: rem-calc(18);
 
-  .backlog-story-input {
-    float: left;
-    max-width: 100%;
-    width: auto;
+  color: $black-40;
+  font-size: $story-font-size;
+  margin-top: - $page-wrapper-margin;
+
+  .user-story-form-container {
+    background-color: $body-bg;
+    padding: rem-calc(15 25);
+
+    &.fixed { border-bottom: 1px solid $black-10; }
   }
+
+  form {
+    @include flexbox();
+    align-items: center;
+
+    > * + * { margin: 0 rem-calc(10); }
+  }
+
+  .backlog-story {
+    @include flex(1);
+    border-bottom: 2px dashed $black-20;
+  }
+
+  .backlog-story-input { display: inline-block; }
 
   input {
     &[type="text"] {
@@ -21,8 +35,8 @@
       @include ellipsis;
       background-color: $body-bg;
       border: 0;
-      font-size: rem-calc(22);
-      margin: 0;
+      font-size: $story-font-size;
+      margin-bottom: 0;
       vertical-align: inherit;
       @include input-placeholder { color: $black-80; };
     }
@@ -32,14 +46,10 @@
   .select-group-dropdown {
     $btn-width: rem-calc(73);
     $btn-height: rem-calc(40);
-    $select-width: rem-calc(180);
+    $select-width: rem-calc(150);
     $select-height: rem-calc(34);
 
-    bottom: - $btn-height / 2;
-    margin: 0;
-    position: absolute;
-    right: $btn-width + rem-calc(20);
-    z-index: 4;
+    margin-bottom: 0;
 
     &.select-group-dropdown {
       height: $select-height;
@@ -50,13 +60,12 @@
 
     &.create-btn {
       background-color: $black-20;
-      right: 0;
 
       @media #{ $small-only } { right: rem-calc(10); }
+
+      &.complete { background-color: $success-color; }
     }//create btn
   }
-
-  .success-button { background-color: $success-color; }
 }//new backlog story
 
 //  USER STORY LIST

--- a/app/views/arbor_reloaded/user_stories/_form.haml
+++ b/app/views/arbor_reloaded/user_stories/_form.haml
@@ -1,37 +1,38 @@
 = form_for(user_story, remote: true, url: arbor_reloaded_project_user_stories_path) do |form|
-  .backlog-story-input.role
-    %span.role-a-an= t('reloaded.backlog.role')
-    = form.text_field(                                   |
-      :role,                                             |
-      placeholder: t('backlog.user_stories.enter_role'), |
-      required:    true,                                 |
-      maxlength:   100,                                  |
-      class:      'role',                                |
-      id:         'role-input',                          |
-      autofocus:  'true',                                |
-    )                                                    |
+  .backlog-story
+    .backlog-story-input.role
+      %span.role-a-an= t('reloaded.backlog.role')
+      = form.text_field(                                   |
+        :role,                                             |
+        placeholder: t('backlog.user_stories.enter_role'), |
+        required:    true,                                 |
+        maxlength:   100,                                  |
+        class:      'role',                                |
+        id:         'role-input',                          |
+        autofocus:  'true',                                |
+      )                                                    |
 
-  .backlog-story-input.action
-    %span= t('reloaded.backlog.action')
-    = form.text_field(                                     |
-      :action,                                             |
-      placeholder: t('backlog.user_stories.enter_action'), |
-      required:    true,                                   |
-      maxlength:   255,                                    |
-      class:      'action',                                |
-      id:         'action-input',                          |
-    )                                                      |
+    .backlog-story-input.action
+      %span= t('reloaded.backlog.action')
+      = form.text_field(                                     |
+        :action,                                             |
+        placeholder: t('backlog.user_stories.enter_action'), |
+        required:    true,                                   |
+        maxlength:   255,                                    |
+        class:      'action',                                |
+        id:         'action-input',                          |
+      )                                                      |
 
-  .backlog-story-input.result
-    %span= t('reloaded.backlog.result')
-    = form.text_field(                                     |
-      :result,                                             |
-      placeholder: t('backlog.user_stories.enter_result'), |
-      required:    true,                                   |
-      maxlength:   255,                                    |
-      class:      'result',                                |
-      id:         'result-input',                          |
-    )                                                      |
+    .backlog-story-input.result
+      %span= t('reloaded.backlog.result')
+      = form.text_field(                                     |
+        :result,                                             |
+        placeholder: t('backlog.user_stories.enter_result'), |
+        required:    true,                                   |
+        maxlength:   255,                                    |
+        class:      'result',                                |
+        id:         'result-input',                          |
+      )                                                      |
 
   = form.select(:group_id, project.groups.map{ |group| [group.name, group.id] }, { include_blank: t('reloaded.user_stories.create.group_select_default') }, class: 'select-group-dropdown')
-  = form.submit t('reloaded.backlog.create'), id: 'save-user-story', class: 'create-btn button radius tiny'
+  = form.submit t('reloaded.backlog.enter'), id: 'save-user-story', class: 'create-btn button radius tiny'

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -1,5 +1,5 @@
-.new-backlog-story.row
-  #user-story-form-container{ data: { new_story_url: new_arbor_reloaded_project_user_story_path(@project) } }
+.new-backlog-story
+  #user-story-form-container.user-story-form-container{ data: { new_story_url: new_arbor_reloaded_project_user_story_path(@project) } }
     = render 'arbor_reloaded/user_stories/form', user_story: UserStory.new, project: @project
 .estimation.row{class: @project.user_stories.count > 0 ? 'visible' : 'hide'}
   .small-12.columns

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
       role: 'As a'
       action: 'I want'
       result: 'so that'
-      create: 'Create'
+      enter: 'Enter'
       save: 'Save'
       cancel: 'Cancel'
     create_group:

--- a/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
+++ b/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
@@ -59,7 +59,7 @@ feature 'Create user story', js: true do
     end
   end
 
-  scenario 'I should be able to assign group top the new user storie' do
+  scenario 'I should be able to assign the group on top to the new story' do
     within 'form#new_user_story' do
       find('#role-input').set(role)
       find('#action-input').set(action)
@@ -70,5 +70,42 @@ feature 'Create user story', js: true do
     wait_for_ajax
 
     expect(UserStory.last.group).to eq(group)
+  end
+
+  context 'when writing the new story' do
+    scenario 'I should see the button on green when all fields contain characters' do
+      within 'form#new_user_story' do
+        fill_in 'role-input', with: 'user'
+        fill_in 'action-input', with: 'I want to see the button with green color when creating stories'
+        fill_in 'result-input', with: 'I know when they are ready to submit'
+
+        expect(page).to have_css('#save-user-story.complete')
+      end
+    end
+
+    scenario 'I should not see the button on green if any field lacks of content' do
+      within 'form#new_user_story' do
+        fill_in 'role-input', with: 'user'
+        fill_in 'action-input', with: 'I should not see the button with green color'
+
+        expect(page).not_to have_css('#save-user-story.complete')
+      end
+    end
+  end
+
+  context 'when navingating on project\'s backlog page' do
+    scenario 'I should be able to see the user story\'s creation bar fixed' do
+      add_height = "$('html').height($(window).height() + $('.new-backlog-story').offset().top)"
+      scroll_to_story_bar = "$(window).scrollTop($('.new-backlog-story').offset().top)"
+
+      page.execute_script(add_height)
+      page.execute_script(scroll_to_story_bar)
+      expect(page).to have_css('.user-story-form-container.fixed')
+    end
+
+    scenario 'I should not see user\'s story creation bar fixed if the user is on top' do
+      page.execute_script('$(window).scrollTop(0)')
+      expect(page).not_to have_css('.user-story-form-container.fixed')
+    end
   end
 end


### PR DESCRIPTION
## Typewriter Design updates

#### Trello board reference:

* [Trello Card #865](https://trello.com/c/9MQXCvHX/865-2-typewriter-design-updates)

---

#### Description:

* The story creation form becomes fixed when the user scrolls down the page, so it is always visible when he is navigating.

---

#### Tasks:

  - [x] Update design of form.

  - [x] Added listeners to window scroll and resize in order to add a class that fix the form to the top of the screen and, a to keep track of the height of it (to avoid a jumpy effect when fixing the form).

  - [x] Form button changes color when all inputs have content.


---

#### Risk:

* Low

---

#### Preview:

<img width="1273" alt="screen shot 2017-01-24 at 1 33 30 pm" src="https://cloud.githubusercontent.com/assets/5388243/22256504/bc68ce44-e239-11e6-81c1-03b5de72879c.png">