### PR TITLE
Allow freeform creation of stories

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/project_backlog.js
@@ -20,12 +20,13 @@ function autogrowInputs() {
 
 function checkForEmptyGroupStories() {
   var $groupDivider = $backlogStoryList.find('.group-divider');
+
   $groupDivider.each(function(index, el) {
-      if ($(el).find('.backlog-user-story').length) {
-        $(el).find('.empty-group-text').addClass('hide');
-      } else {
-        $(el).find('.empty-group-text').removeClass('hide');
-      }
+    if ($(el).find('.backlog-user-story').length) {
+      $(el).find('.empty-group-text').addClass('hide');
+    } else {
+      $(el).find('.empty-group-text').removeClass('hide');
+    }
   });
 }
 
@@ -48,9 +49,11 @@ function bindReorderStories() {
     stop: function(event, ui) {
       checkForEmptyGroupStories();
       $(ui.item).attr('style', '');
+
       var newStoriesOrder = setStoriesOrder(),
-          url = $reorder_stories.data('url');
+          url = $reorder_stories.data('url'),
           project = $reorder_stories.data('project');
+
       $.ajax({
         url: url,
         dataType: 'json',
@@ -71,7 +74,7 @@ function bindReorderStories() {
 
 function setStoriesOrder() {
   var newStoriesOrder = { stories: [] },
-      $updatedStoriesOnList = $('li.backlog-user-story');
+      $updatedStoriesOnList = $('li.backlog-user-story'),
       length = $updatedStoriesOnList.length + 1;
 
   $.each($updatedStoriesOnList, function(index) {
@@ -96,12 +99,14 @@ function showBulkMenu() {
 
 function removeColors(userStoryID) {
   var $backlogStory = $('#backlog-user-story-' + userStoryID);
+
   for (var i = 1; i <= 7; i++) { $backlogStory.removeClass('story-tag-' + i); }
 }
 
 function addColor(userStoryID, colorID) {
   removeColors(userStoryID);
-  if(colorID) {
+
+  if (colorID) {
     $('#backlog-user-story-' + userStoryID).addClass('story-tag-' + colorID);
   }
 }
@@ -137,8 +142,8 @@ function bindUserStoriesColorLinks() {
 
 function toggleGroupForm() {
   $(document).on('click', '.form-group-container h5', function(event) {
-    $this = $(this);
-    $formEditName = $this.closest('.form-group-container').find('.form-container');
+    var $this = $(this),
+        $formEditName = $this.closest('.form-group-container').find('.form-container');
 
     $this.addClass('hidden-element');
     $formEditName.removeClass('hidden-element');
@@ -172,20 +177,22 @@ function refreshProjectEstimations(total_points, total_cost, total_weeks) {
 }
 
 function onNewBacklogStoryInputKeyup() {
-  var $backlogStoryInput = $('.backlog-story-input input'),
-      $saveStoryButton   = $('#save-user-story');
+  $('.backlog-story').parent('form').each(function (_, form) {
+    var $backlogStoryInput = $('.backlog-story-input input', form),
+        $saveStoryButton   = $('.save-user-story', form);
 
-  $backlogStoryInput.keyup(function() {
-    var count = $backlogStoryInput.filter(function() {
-      return $(this).val().length > 0;
-    }).length;
+    $backlogStoryInput.keyup(function() {
+      var count = $backlogStoryInput.filter(function() {
+        return $(this).val().length > 0;
+      }).length;
 
-    if (count === $backlogStoryInput.length) {
-      $saveStoryButton.addClass('complete');
-    } else {
-      $saveStoryButton.removeClass('complete');
-    }
-  })
+      if (count === $backlogStoryInput.length) {
+        $saveStoryButton.addClass('complete');
+      } else {
+        $saveStoryButton.removeClass('complete');
+      }
+    });
+  });
 }
 
 function fixNewBacklogStoryOnTop() {
@@ -200,16 +207,50 @@ function fixNewBacklogStoryOnTop() {
 }
 
 function fixNewBacklogStoryHeight() {
-    var $newBacklogStory        = $('.new-backlog-story'),
-        $userStoryFormContainer = $('#user-story-form-container');
+  var $newBacklogStory        = $('.new-backlog-story'),
+      $userStoryFormContainer = $('#user-story-form-container');
 
-    $newBacklogStory.height($userStoryFormContainer.outerHeight());
+  $newBacklogStory.height($userStoryFormContainer.outerHeight());
+}
+
+function bindCreationMode() {
+  $('.backlog-story-creation-mode').each(function (i, item) {
+    var $item = $(item);
+
+    $('.creation-mode-selected', $item).click(function () {
+      $('ul.creation-mode-list', $item).removeClass('hidden-element');
+    });
+
+    $('li.creation-mode-guided', $item).click(function () {
+      $('.creation-mode-selected .creation-mode-icon', $item).text("G");
+
+      $('form.creation-mode-guided').removeClass('hidden-element');
+      $('form.creation-mode-freeform').addClass('hidden-element');
+    });
+
+    $('li.creation-mode-freeform', $item).click(function () {
+      $('.creation-mode-selected .creation-mode-icon', $item).text("F");
+
+      $('form.creation-mode-guided').addClass('hidden-element');
+      $('form.creation-mode-freeform').removeClass('hidden-element');
+    });
+  });
+
+  $(document).click(function (event) {
+    var $element = $(event.target);
+
+    if ($element.parents('.creation-mode-selected').length !== 1 &&
+        !$element.is('.creation-mode-selected')) {
+      $('ul.creation-mode-list').addClass('hidden-element');
+    }
+  });
 }
 
 $(document).ready(function() {
   if ($('.new-backlog-story').length > 0) { autogrowInputs(); }
 
   if ($backlogStoryList.length) {
+    bindCreationMode();
     showBulkMenu();
     bindReorderStories();
     checkForEmptyGroupStories();
@@ -226,7 +267,7 @@ $(document).ready(function() {
   }
 });
 
-$( window ).resize(function() { autogrowInputs(); });
+$(window).resize(function() { autogrowInputs(); });
 
 function backlogGeneralBinds() {
   fixArticlesForRolesOnBacklog();

--- a/app/assets/javascripts/arbor-reloaded/user_stories/check_if_filled.js
+++ b/app/assets/javascripts/arbor-reloaded/user_stories/check_if_filled.js
@@ -14,7 +14,7 @@ function changeButtonColor() {
     if (count === 3) {
       $('.create-btn').addClass('success-button');
     } else {
-        $('.create-btn').removeClass('success-button');
+      $('.create-btn').removeClass('success-button');
     }
   });
 }

--- a/app/assets/stylesheets/arbor_reloaded/_backlog.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_backlog.scss
@@ -1,6 +1,59 @@
 //  CREATE USER STORY
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
+
+.backlog-story-creation-mode {
+  .creation-mode-icon {
+    color: $black-20;
+    font-family: serif;
+    font-size: rem-calc(25);
+    font-weight: bold;
+  }
+
+  i {
+    font-size: rem-calc(5);
+    margin-left: rem-calc(5);
+  }
+
+  .creation-mode-selected {
+    @include flexbox();
+    align-items: center;
+    cursor: pointer;
+    height: 100%;
+
+    i {
+      margin-left: rem-calc(5);
+    }
+  }
+
+  ul {
+    @include box-shadow(0 0 14px 1px $creation-mode-shadow);
+    background: $body-bg;
+    min-width: rem-calc(278);
+    position: absolute;
+
+    li {
+      border-bottom: 1px solid $border-color;
+      color: $black;
+      margin: rem-calc(3);
+      padding: rem-calc(10);
+
+      .creation-mode-icon {
+        margin: rem-calc(8);
+      }
+
+      &:last-child {
+        border: 0;
+      }
+
+      &:hover {
+        background: $light-grey;
+        cursor: pointer;
+      }
+    }
+  }
+}
+
 .new-backlog-story {
   $story-font-size: rem-calc(18);
 
@@ -9,6 +62,7 @@
   margin-top: - $page-wrapper-margin;
 
   .user-story-form-container {
+    @include flexbox();
     background-color: $body-bg;
     padding: rem-calc(15 25);
 
@@ -17,6 +71,7 @@
 
   form {
     @include flexbox();
+    @include flex(1);
     align-items: center;
 
     > * + * { margin: 0 rem-calc(10); }

--- a/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
+++ b/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
@@ -23,6 +23,7 @@ $error-color: $canvas-color;
 $warning-color: #fbab1f;
 $lab-color: #4ba4f6;
 $backlog-color: $success-color;
+$creation-mode-shadow: rgba(0, 0, 0, .45);
 $icon-color: #53565f;
 $light-bg: #fbfbfb;
 $font-color-2: #626262;

--- a/app/views/arbor_reloaded/user_stories/_form.haml
+++ b/app/views/arbor_reloaded/user_stories/_form.haml
@@ -1,4 +1,16 @@
-= form_for(user_story, remote: true, url: arbor_reloaded_project_user_stories_path) do |form|
+.backlog-story-creation-mode
+  .creation-mode-selected
+    %span.creation-mode-icon G
+    %i.icn-arrow-dropdown &nbsp;
+  %ul.creation-mode-list.hidden-element
+    %li.creation-mode-list-item.creation-mode-guided
+      %span.creation-mode-icon G
+      Guided
+    %li.creation-mode-list-item.creation-mode-freeform
+      %span.creation-mode-icon F
+      Freeform
+
+= form_for(user_story, remote: true, html: { class: 'creation-mode-guided' }, url: arbor_reloaded_project_user_stories_path) do |form|
   .backlog-story
     .backlog-story-input.role
       %span.role-a-an= t('reloaded.backlog.role')
@@ -35,4 +47,20 @@
       )                                                      |
 
   = form.select(:group_id, project.groups.map{ |group| [group.name, group.id] }, { include_blank: t('reloaded.user_stories.create.group_select_default') }, class: 'select-group-dropdown')
-  = form.submit t('reloaded.backlog.enter'), id: 'save-user-story', class: 'create-btn button radius tiny'
+  = form.submit t('reloaded.backlog.enter'), class: 'save-user-story create-btn button radius tiny'
+
+= form_for(user_story, remote: true, html: { id: 'new_free_user_story', class: 'creation-mode-freeform hidden-element' }, url: arbor_reloaded_project_user_stories_path) do |form|
+  .backlog-story
+    .backlog-story-input.description
+      = form.text_field(                                   |
+        :description,                                      |
+        placeholder: t('backlog.user_stories.free'),       |
+        required:    true,                                 |
+        maxlength:   400,                                  |
+        class:      'description',                         |
+        id:         'description-input',                   |
+        autofocus:  'true',                                |
+      )                                                    |
+
+  = form.select(:group_id, project.groups.map{ |group| [group.name, group.id] }, { include_blank: t('reloaded.user_stories.create.group_select_default') }, class: 'select-group-dropdown')
+  = form.submit t('reloaded.backlog.enter'), class: 'save-user-story create-btn button radius tiny'

--- a/app/views/arbor_reloaded/user_stories/create.js.erb
+++ b/app/views/arbor_reloaded/user_stories/create.js.erb
@@ -1,6 +1,10 @@
-$('.backlog-story-input.role input').val('');
-$('.backlog-story-input.role input').focus();
-$('.backlog-story-input.action input').val('');
-$('.backlog-story-input.result input').val('');
+$('.backlog-story-input input').val('');
+
+if ($('form.creation-mode-guided').is('hidden-element')) {
+  $('.backlog-story-input.description input').focus();
+} else {
+  $('.backlog-story-input.role input').focus();
+}
+
 $('.user-stories-container').html("<%= j render 'arbor_reloaded/user_stories/user_stories_list', project: @user_story.project.reload, new_group_top: Group.new(project_id: @user_story.project.id, order: 0), new_group_bottom: Group.new(project_id: @user_story.project.id) %>");
 backlogGeneralBinds();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
       Are you sure you want to continue?
   backlog:
     user_stories:
+      free: "As a <type of user> I want <some function> so that <some benefit>"
       enter_role: "<type of user>"
       enter_action: "<some function>"
       enter_result: "<some benefit>"

--- a/spec/features/arbor_reloaded/project/log_spec.rb
+++ b/spec/features/arbor_reloaded/project/log_spec.rb
@@ -70,12 +70,12 @@ feature 'Log activity'do
           .to receive(:create_event).and_return(true)
 
         PublicActivity.with_tracking do
-          within 'form.new_user_story' do
+          within 'form#new_user_story' do
             find('#role-input').set(user_story.role)
             find('#action-input').set(user_story.action)
             find('#result-input').set(user_story.result)
+            find('input.save-user-story').click
           end
-          find('input#save-user-story').click
         end
 
         expect(project.activities.first.key).to eq('project.add_user_story')

--- a/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
+++ b/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
@@ -1,94 +1,132 @@
 require 'spec_helper'
 
 feature 'Create user story', js: true do
-  let!(:user)    { create :user }
-  let!(:project) { create :project, owner: user }
-  let(:role)     { Faker::Lorem.word }
-  let(:action)   { Faker::Lorem.word }
-  let(:result)   { Faker::Lorem.word }
-  let!(:group)   { create :group, project: project }
+  let!(:user)       { create :user }
+  let!(:project)    { create :project, owner: user }
+  let(:role)        { Faker::Lorem.word }
+  let(:action)      { Faker::Lorem.word }
+  let(:result)      { Faker::Lorem.word }
+  let(:description) { Faker::Lorem.word }
+  let!(:group)      { create :group, project: project }
 
   background do
     sign_in user
     visit arbor_reloaded_project_user_stories_path(project)
   end
 
-  scenario 'should shown the user story form' do
-    expect(page).to have_css 'form#new_user_story'
+  scenario 'should show control for switching mode' do
+    expect(page).to have_css '.backlog-story-creation-mode'
   end
 
-  scenario 'should create the story on database with the correct role' do
-    within 'form#new_user_story' do
-      find('#role-input').set(role)
-      find('#action-input').set(action)
-      find('#result-input').set(result)
-      find('#save-user-story').click
-    end
-    wait_for_ajax
-
-    expect(UserStory.last.role).to eq(role)
-  end
-
-  scenario 'should create the story on database with the correct action' do
-    within 'form#new_user_story' do
-      find('#role-input').set(role)
-      find('#action-input').set(action)
-      find('#result-input').set(result)
-      find('#save-user-story').click
-    end
-    wait_for_ajax
-
-    expect(UserStory.last.action).to eq(action)
-  end
-
-  scenario 'should create the story on database with the correct result' do
-    within 'form#new_user_story' do
-      find('#role-input').set(role)
-      find('#action-input').set(action)
-      find('#result-input').set(result)
-      find('#save-user-story').click
-    end
-    wait_for_ajax
-
-    expect(UserStory.last.result).to eq(result)
-  end
-
-  scenario 'I should be able to see the group select' do
-    within '.new_user_story' do
-      expect(page).to have_css('#user_story_group_id')
-    end
-  end
-
-  scenario 'I should be able to assign the group on top to the new story' do
-    within 'form#new_user_story' do
-      find('#role-input').set(role)
-      find('#action-input').set(action)
-      find('#result-input').set(result)
-      find('#user_story_group_id').find("option[value='#{group.id}']").select_option
-      find('#save-user-story').click
-    end
-    wait_for_ajax
-
-    expect(UserStory.last.group).to eq(group)
-  end
-
-  context 'when writing the new story' do
-    scenario 'I should see the button on green when all fields contain characters' do
-      within 'form#new_user_story' do
-        fill_in 'role-input', with: 'user'
-        fill_in 'action-input', with: 'I want to see the button with green color when creating stories'
-        fill_in 'result-input', with: 'I know when they are ready to submit'
-
-        expect(page).to have_css('#save-user-story.complete')
+  context 'switching to freeform flow' do
+    before do
+      within '.backlog-story-creation-mode' do
+        find('.creation-mode-icon').click
+        find('.creation-mode-freeform').click
       end
     end
 
-    scenario 'I should not see the button on green if any field lacks of content' do
-      within 'form#new_user_story' do
-        fill_in 'role-input', with: 'user'
-        fill_in 'action-input', with: 'I should not see the button with green color'
+    scenario 'should show the freeform user story form' do
+      expect(page).to have_css'form#new_free_user_story'
+    end
 
-        expect(page).not_to have_css('#save-user-story.complete')
+
+    scenario 'should create the story on database with the correct description' do
+      within 'form#new_free_user_story' do
+        find('#description-input').set(description)
+        find('.save-user-story').click
+      end
+      wait_for_ajax
+
+      expect(UserStory.last.description).to eq(description)
+    end
+  end
+
+  context 'switching to guided flow' do
+    before do
+      within '.backlog-story-creation-mode' do
+        find('.creation-mode-icon').click
+        find('.creation-mode-guided').click
+      end
+    end
+
+    scenario 'should shown the user story form' do
+      expect(page).to have_css'form#new_user_story'
+    end
+
+    scenario 'should create the story on database with the correct role' do
+      within 'form#new_user_story' do
+        find('#role-input').set(role)
+        find('#action-input').set(action)
+        find('#result-input').set(result)
+        find('.save-user-story').click
+      end
+      wait_for_ajax
+
+      expect(UserStory.last.role).to eq(role)
+    end
+
+    scenario 'should create the story on database with the correct action' do
+      within 'form#new_user_story' do
+        find('#role-input').set(role)
+        find('#action-input').set(action)
+        find('#result-input').set(result)
+        find('.save-user-story').click
+      end
+      wait_for_ajax
+
+      expect(UserStory.last.action).to eq(action)
+    end
+
+    scenario 'should create the story on database with the correct result' do
+      within 'form#new_user_story' do
+        find('#role-input').set(role)
+        find('#action-input').set(action)
+        find('#result-input').set(result)
+        find('.save-user-story').click
+      end
+      wait_for_ajax
+
+      expect(UserStory.last.result).to eq(result)
+    end
+
+    scenario 'I should be able to see the group select' do
+      within '#new_user_story' do
+        expect(page).to have_css('#user_story_group_id')
+      end
+    end
+
+    scenario 'I should be able to assign the group on top to the new story' do
+      within 'form#new_user_story' do
+        find('#role-input').set(role)
+        find('#action-input').set(action)
+        find('#result-input').set(result)
+        find('#user_story_group_id').find("option[value='#{group.id}']").select_option
+        find('.save-user-story').click
+      end
+      wait_for_ajax
+
+      expect(UserStory.last.group).to eq(group)
+    end
+
+    context 'when writing the new story' do
+      scenario 'I should see the button on green when all fields contain characters' do
+        within 'form#new_user_story' do
+          fill_in 'role-input', with: 'user'
+          fill_in 'action-input', with: 'I want to see the button with green color when creating stories'
+          fill_in 'result-input', with: 'I know when they are ready to submit'
+
+          expect(page).to have_css('.save-user-story.complete')
+        end
+      end
+
+      scenario 'I should not see the button on green if any field lacks of content' do
+        within 'form#new_user_story' do
+          fill_in 'role-input', with: 'user'
+          fill_in 'action-input', with: 'I should not see the button with green color'
+
+          expect(page).not_to have_css('.save-user-story.complete')
+        end
       end
     end
   end


### PR DESCRIPTION
# When creating a story, the user can now choose between `guided` and `freeform`.

- Guided: Will have the input for `role`, `action` and `result`, as before.
- Freeform: Will have only one input where the user can enter any text that describes the story.

## Trello reference

[Trello card #731](https://trello.com/c/dRv6GV5r/731-as-a-user-i-should-be-able-to-select-the-user-story-creation-mode-guided-or-free-form)


![image](https://cloud.githubusercontent.com/assets/263335/22302828/5ae09284-e30f-11e6-9496-bc3a8273b814.png)


![image](https://cloud.githubusercontent.com/assets/263335/22302838/60467f68-e30f-11e6-9ebd-de06f073d0eb.png)
