### PR TITLE
Fix issue on cancel delete story

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/projects/user_story_modal_binds.js
+++ b/app/assets/javascripts/arbor-reloaded/projects/user_story_modal_binds.js
@@ -61,6 +61,16 @@ $(document).on('click', '#acceptance-list .criterion', {}, function(event) {
   });
 });
 
+$(document).on('click', '.delete-confirmation-overlay .cancel', {}, function (event) {
+  var $overlay       = $(event.target).closest('.delete-confirmation-overlay'),
+      $overlayParent = $overlay.parent();
+
+  $overlay.removeClass('active');
+  $overlayParent.find('.header-wrapper').removeClass('inactive');
+
+  event.preventDefault();
+});
+
 $(document).on('click', '.story-actions .icn-delete', {}, function(event) {
   var $storyModalHeader    = $(this).parent().parent().parent(),
       $confirmationWarning = $storyModalHeader.find('.delete-confirmation-overlay'),

--- a/spec/controllers/arbor_reloaded/teams_controller_spec.rb
+++ b/spec/controllers/arbor_reloaded/teams_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ArborReloaded::TeamsController do
         )
         team.reload
         expect{ team.users.reload.count }.to become_eq 2
-        expect(team.users.last).to eq(another_user)
+        expect(team.users).to include(another_user)
       end
 
       context 'if the signed user is not the owner' do

--- a/spec/features/arbor_reloaded/user_stories/story_detail_spec.rb
+++ b/spec/features/arbor_reloaded/user_stories/story_detail_spec.rb
@@ -46,6 +46,46 @@ feature 'Story detail modal', js:true do
     expect(user_story.description).to eq('This is the new user story')
   end
 
+  context 'clicking delete' do
+    before do
+      find('.story-actions').click
+      within '#story-detail-modal' do
+        find('a.icn-delete').click
+      end
+    end
+
+    scenario 'shows delete confirmation' do
+      within '#story-detail-modal' do
+        expect(page).to have_text('Are you sure you want to delete this user story?')
+        expect(page).to have_text('Yes, delete it')
+        expect(page).to have_text('Cancel')
+      end
+    end
+
+    context 'canceling deletion' do
+      scenario 'does not delete the story' do
+        within '#story-detail-modal' do
+          click_link('Cancel')
+
+          expect(UserStory.find_by_id(user_story.id)).to_not be_nil
+          expect(page).to_not have_text('Yes, delete it')
+        end
+      end
+    end
+
+    context 'confirming deletion' do
+      scenario 'deletes the story' do
+        within '#story-detail-modal' do
+          click_link('Yes, delete it')
+
+          wait_for_ajax
+
+          expect(UserStory.find_by_id(user_story.id)).to be_nil
+        end
+      end
+    end
+  end
+
   scenario 'should be able to see other actions' do
     find('.story-actions').click
     within '#story-detail-modal' do


### PR DESCRIPTION
# Allow cancel deleting story

[Trello story #903](https://trello.com/c/W6I7u366/903-qa-bug-903-does-not-leave-the-popup-to-clear-the-hitorial)

When user opens the story details modal, clicks delete and then tries to cancel it wont work.

## Risk

- Low