### PR TITLE
Force push to heroku to avoid rejects

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,6 @@ deployment:
     branch: master
     commands:
       - heroku maintenance:on --app arbor-2-development
-      - git push git@heroku.com:arbor-2-development.git $CIRCLE_SHA1:refs/heads/master
+      - git push --force git@heroku.com:arbor-2-development.git $CIRCLE_SHA1:refs/heads/master
       - heroku run rake db:migrate --app arbor-2-development
       - heroku maintenance:off --app arbor-2-development


### PR DESCRIPTION
# Force push to heroku

CircleCI deploy fails due to history differences. Adding the `--force` should fix the issue. Since it is the development instance, it shouldn't be a problem.