### PR TITLE
Revert "Force push to heroku to avoid rejects"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,6 @@ deployment:
     branch: master
     commands:
       - heroku maintenance:on --app arbor-2-development
-      - git push --force git@heroku.com:arbor-2-development.git $CIRCLE_SHA1:refs/heads/master
+      - git push git@heroku.com:arbor-2-development.git $CIRCLE_SHA1:refs/heads/master
       - heroku run rake db:migrate --app arbor-2-development
       - heroku maintenance:off --app arbor-2-development


### PR DESCRIPTION
This reverts commit 2212207256dfc65457e91db13696e334e3c2d4c0.

Given that CircleCI stores a shallow clone of the repo, a `push --force` is not possible. Reverting back to the original.