### PR TITLE
Add validations on profile image

### DIFF
--- a/app/assets/javascripts/arbor-reloaded/user_profile/user_profile.js
+++ b/app/assets/javascripts/arbor-reloaded/user_profile/user_profile.js
@@ -3,16 +3,70 @@ $(document).on('click', '#copy-token', {}, function(event) {
   return false;
 });
 
+var MAX_FILE_SIZE = 3;
 
+function fileIsAnImage(file) {
+  var imageType = file.type && file.type.split("/")[0];
+
+  return imageType === "image" && file.size > 0;
+}
+
+function fileSizeIsValid(file, maxSize) {
+  return ((file.size / 1024) / 1024) <= maxSize;
+}
+
+function validateFile(input) {
+  var file = input.files && input.files[0],
+      error = null;
+
+  if (!file) {
+    return { error: null, file: null };
+  }
+
+  if (fileSizeIsValid(file, MAX_FILE_SIZE)) {
+    if (fileIsAnImage(file)) {
+      return { file: file };
+    }
+
+    error = 'File is not an image';
+  } else {
+    error = 'File is too big';
+  }
+
+  input.value = null;
+
+  return { file: null, error: error };
+}
+
+function displayFormError(message) {
+  $(document).trigger('formNotification.error', message);
+}
 
 function readURL(input) {
-  if (input.files && input.files[0]) {
-    var reader = new FileReader();
+  var result = validateFile(input),
+      reader = null;
 
-    reader.onload = function (e) {
-      $('#img_prev').css('background-image', 'url(' + e.target.result + ')');
-    };
 
-    reader.readAsDataURL(input.files[0]);
+  if (!result.file) {
+    if (result.error) {
+      displayFormError(result.error);
+    }
+
+    $('#img_prev').css('background-image', '');
+    return false;
   }
+
+  reader = new FileReader();
+
+  reader.onerror = function (e) {
+    console.log("Error", e);
+    input.value = null;
+    displayFormError('Something went wrong with that file');
+  };
+
+  reader.onload = function (e) {
+    $('#img_prev').css('background-image', 'url(' + e.target.result + ')');
+  };
+
+  reader.readAsDataURL(result.file);
 }

--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -31,6 +31,17 @@ UTIL = {
   }
 };
 
+$(document).bind('formNotification.error', function (event, text) {
+  var $div = $('<div></div>').text(text).addClass("alert-box error");
+
+  $('<a></a>').attr('href', '#').addClass('close').text('×').appendTo($div);
+  $div.insertAfter('.secondary-nav').show();
+
+  setTimeout(function () {
+    $div.fadeOut();
+  }, 2000);
+});
+
 $(document).ready(function() {
   UTIL.init();
 

--- a/app/views/arbor_reloaded/users/show.html.haml
+++ b/app/views/arbor_reloaded/users/show.html.haml
@@ -6,7 +6,7 @@
   .user-header
     .user-avatar
       %span.icn-edit
-      = f.file_field :avatar, class: 'icn-edit', id: 'edit-user-avatar-link', onchange:'readURL(this);'
+      = f.file_field :avatar, accept: 'image/*', class: 'icn-edit', id: 'edit-user-avatar-link', onchange:'readURL(this);'
       - if current_user.avatar?
         .avatar-img{ style: "background-image: url(#{ current_user.avatar_url });" }
       - else


### PR DESCRIPTION
# Add validations on profile image

When uploading an image, errors are not displayed. This adds some validations and messages to let the user know why the image wasn't accepted.

Added:
- Validations to image upload on javascript.
- Validation messages.
- Filter file type by images on upload dialog.
- Reset uploaded image on failure to make it consistent.

## Trello card reference

[Trello card #898](https://trello.com/c/UQJ2edL3/898-qa-bug-898-the-error-is-not-displayed-when-attempting-to-place-a-file-invalid-profile-photo)