### PR TITLE
Add updates popup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,4 @@ ENABLE_INTERCOM=false
 ADMIN_USERNAME=
 ADMIN_PASSWORD=
 FEEDBACK_URL='https://docs.google.com/a/neonroots.com/forms/d/e/1FAIpQLSfyNGDvHFrF8rjaw5q7zI9MpgpXwkvdUEgTRcWTmQjEThPokw/viewform'
+UPDATES_URL='http://example.com'

--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,4 @@ SLACK_ACCESS_URL=https://slack.com/api/oauth.access
 SLACK_DATA_URL=https://slack.com/api/auth.test
 SLACK_CONNECT_URL_NOTIFICATION=getarbor.io
 FEEDBACK_URL='https://docs.google.com/a/neonroots.com/forms/d/e/1FAIpQLSfyNGDvHFrF8rjaw5q7zI9MpgpXwkvdUEgTRcWTmQjEThPokw/viewform'
+UPDATES_URL=http://example.com

--- a/app/assets/javascripts/arbor-reloaded/main.js
+++ b/app/assets/javascripts/arbor-reloaded/main.js
@@ -113,3 +113,21 @@ function setVisibleState(elements, reversed){
     }
   });
 }
+
+$('#updates-popup .dismiss').click(function (event) {
+  $('#updates-popup').hide();
+
+  if (!$(event.target).is('.learn-more')) {
+    event.preventDefault();
+  }
+});
+
+$(document).on('click', '.new-updates .dismiss', function (event) {
+  $(event.target).closest('.new-updates').removeClass('new-updates');
+
+  $.post($(event.target).data('url'));
+});
+
+$('.show-updates-popup').click(function () {
+  $('#updates-popup').toggle();
+});

--- a/app/assets/stylesheets/application_reload.scss
+++ b/app/assets/stylesheets/application_reload.scss
@@ -26,3 +26,4 @@
 @import 'arbor_reloaded/project_activities';
 @import 'arbor_reloaded/slack-button';
 @import 'arbor_reloaded/slack-modal';
+@import 'arbor_reloaded/updates_popup';

--- a/app/assets/stylesheets/arbor_reloaded/_navigation.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_navigation.scss
@@ -66,32 +66,47 @@ $avatar-dimension: rem-calc(40);
   }//notification on bell
 }//top-bar
 
-.top-bar-section .profile {
-  .avatar {
-    @include user-avatar($avatar-dimension, rem-calc(20));
+.top-bar-section {
+  .show-updates-popup i { font-size: rem-calc(28); }
 
-    @media #{ $medium-only } { margin: rem-calc(10 15 0 0); }
-    @media #{ $medium-up } { @include inline-block; }
-  }//avatar
+  .new-updates .show-updates-popup {
+    i { color: $updates-color; }
 
-  a:not(.button) {
-    &#welcome {
-      color: $black-30;
-      display: inline;
-      font-size: rem-calc(13);
-      padding-right: 0;
-      width: calc(100% - #{$avatar-dimension});
-
-      span {
-        color: $white;
-        font-weight: $font-weight-bold;
-      }
-
-      @media #{ $small-only } { display: block; }
-      @media #{ $medium-only } { display: none; }
-    }//welcome tag
+    &:hover i { color: lighten($updates-color, 25%); }
   }
-}//profile section in nav
+
+  .profile {
+    .avatar {
+      @include user-avatar($avatar-dimension, rem-calc(20));
+
+      @media #{ $medium-only } { margin: rem-calc(10 15 0 0); }
+      @media #{ $medium-up } { @include inline-block; }
+    }//avatar
+
+    a:not(.button) {
+      &#welcome {
+        color: $black-30;
+        display: inline;
+        font-size: rem-calc(13);
+        padding-right: 0;
+        width: calc(100% - #{$avatar-dimension});
+
+        span {
+          color: $white;
+          font-weight: $font-weight-bold;
+        }
+
+        @media #{ $small-only } { display: block; }
+        @media #{ $medium-only } { display: none; }
+      }//welcome tag
+    }
+  }//profile section in nav
+
+  ul .f-dropdown {
+    // scss-lint:disable ImportantRule
+    top: $topbar-height !important;
+  }
+}
 
 // DROPDOWNS
 // - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -108,11 +123,6 @@ ul .f-dropdown {
     }// span icons
   }// li and a
 }//f-dropdown
-
-.top-bar-section ul .f-dropdown {
-  // scss-lint:disable ImportantRule
-  top: $topbar-height !important;
-}
 
 ul .dropdown {
   span {

--- a/app/assets/stylesheets/arbor_reloaded/_updates_popup.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_updates_popup.scss
@@ -1,0 +1,39 @@
+#updates-popup {
+  @include box-shadow($shadow-depth-popup);
+
+  background: $white;
+  display: none;
+  left: calc(100% - 450px);
+  padding: rem-calc(10);
+  position: absolute;
+  width: rem-calc(300);
+  z-index: 1;
+
+  p {
+    color: $black-35;
+    font-size: rem-calc(13);
+    margin: 0;
+    text-align: center;
+  }
+
+  h5 {
+    font-family: $font-family-sans-serif;
+    font-size: rem-calc(14);
+    margin-top: rem-calc(140);
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .dismiss {
+    background: $white;
+  }
+
+  .learn-more {
+    color: $inactive-green;
+    font-weight: bold;
+  }
+}
+
+.new-updates #updates-popup {
+  display: initial;
+}

--- a/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
+++ b/app/assets/stylesheets/arbor_reloaded/assets/_base.scss
@@ -34,6 +34,7 @@ $modal-bg-color: #ececec;
 $light-blue: #a6b6bd;
 $light-blue-2: #eceff1;
 $inactive-green: #49df7a;
+$updates-color: #c2b705;
 
 // Favorite project random colors
 
@@ -83,6 +84,7 @@ $light-grey: #eff0ef;
 
 // ------- SHADOWS' DEPTH ------ //
 $shadow-depth-1: rgba($black-50, .3) 1px 1px 2px;
+$shadow-depth-popup: rgba($black-50, .7) 2px 2px 9px;
 $shadow-depth-hover: rgba($black-50, .2) 3px 8px 25px;
 
 // -------  MIXINS ------ //

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   layout :layout_by_resource
   force_ssl if: :ssl_configured?
+  before_action :updates_status
 
   private
 
@@ -15,6 +16,10 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+
+  def updates_status
+    @dismiss_updates = session['dismiss_updates']
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) << :full_name

--- a/app/controllers/arbor_reloaded/users_controller.rb
+++ b/app/controllers/arbor_reloaded/users_controller.rb
@@ -5,5 +5,11 @@ module ArborReloaded
 
     def show
     end
+
+    def read_updates
+      session[:dismiss_updates] = 1
+
+      head :no_content
+    end
   end
 end

--- a/app/services/arbor_reloaded/slack_integration_service.rb
+++ b/app/services/arbor_reloaded/slack_integration_service.rb
@@ -45,6 +45,8 @@ module ArborReloaded
     end
 
     def req_slack_data(token)
+      return {} unless @data_url
+
       options = {
         token: token
       }

--- a/app/views/layouts/_navigation.haml
+++ b/app/views/layouts/_navigation.haml
@@ -26,6 +26,18 @@
           %li.hide
             = link_to log_arbor_reloaded_project_path(current_project) do
               %span.icn-notifications
+        %li{class: dismiss_updates ? nil : 'new-updates'}
+          %a.show-updates-popup
+            %i.icn-favorite
+
+          %div#updates-popup
+            %h5= t('reloaded.updates.title')
+            %p= t('reloaded.updates.description')
+            %p
+              = link_to t('reloaded.updates.learn_more'), arbor_reloaded_updates_path,
+                data: { url: arbor_reloaded_read_updates_path }, class: 'learn-more dismiss', target: '_blank'
+              = link_to t('reloaded.updates.dismiss'), '#', data: { url: arbor_reloaded_read_updates_path }, class: 'dismiss'
+
       %ul.profile
         %li.user-dropdown.has-dropdown.clearfix
           -# .not-click

--- a/app/views/layouts/application_reload.html.haml
+++ b/app/views/layouts/application_reload.html.haml
@@ -27,7 +27,8 @@
     :javascript
       try{Typekit.load();}catch(e){}
   %body{'data-action' => action_name, 'data-controller' => controller_name }
-    = render 'layouts/navigation', projects: @projects, current_project: @project, google_sheets_response: @google_sheets_response
+    = render 'layouts/navigation', projects: @projects, current_project: @project,
+      google_sheets_response: @google_sheets_response, dismiss_updates: @dismiss_updates
     = yield :user_nav
     - if Rails.env.production?
       // Intercom plugin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,13 @@ en:
     groups:
       create: 'Click here to add a theme'
       delete_group_confirm: 'Are you sure you want to delete this theme?'
+    updates:
+      learn_more: 'Learn More'
+      dismiss: 'Dismiss'
+      title: 'New product updates'
+      description: |
+        From Canvas, to Themes, to Typewriter,
+        discover all the new updates on Arbor.
   slack:
     notifications:
       story_created: 'New user story created'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Railsroot::Application.routes.draw do
     get 'feedback' => redirect(ENV['FEEDBACK_URL'])
     get 'projects/list', controller: :projects, action: :list_projects
 
+    post 'read-updates', to: 'users#read_updates'
+    get 'updates' => redirect(ENV['UPDATES_URL'])
+
     resources :projects, except: [:new, :edit], shallow: true do
       resources :trello, only: [:new, :create, :index, :update]
       get 'export_to_google', controller: :google_sheets,

--- a/spec/features/arbor_reloaded/updates_tab/updates_spec.rb
+++ b/spec/features/arbor_reloaded/updates_tab/updates_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+feature 'Updates tab', js:true do
+  let!(:user) { create :user,
+    full_name: 'Jhon Doe',
+    email: 'jhon.doe@mail.com'
+  }
+
+  context 'As a User logged' do
+    background do
+      sign_in user
+      visit arbor_reloaded_root_path
+    end
+
+    context 'oppening the page for first time' do
+      scenario 'I should see the updates popup' do
+        expect(page).to have_css('.top-bar-section .new-updates')
+        expect(page).to have_text('NEW PRODUCT UPDATES')
+      end
+
+      context 'clicking Dismiss' do
+        before do
+          within('.top-bar-section .new-updates') do
+            click_link('Dismiss')
+            wait_for_ajax
+          end
+        end
+
+        scenario 'should hide popup menu' do
+          expect(page).to_not have_css('.top-bar-section .new-updates')
+          expect(page).to_not have_text('NEW PRODUCT UPDATES')
+        end
+
+        context 're visiting the site' do
+          scenario 'should not display the popup' do
+            visit arbor_reloaded_root_path
+
+            expect(page).to_not have_css('.top-bar-section .new-updates')
+            expect(page).to_not have_text('NEW PRODUCT UPDATES')
+          end
+        end
+      end
+
+      context 'clicking Learn More' do
+        before do
+          within('.top-bar-section .new-updates') do
+            click_link('Learn More')
+            wait_for_ajax
+          end
+        end
+
+        scenario 'should hide popup menu' do
+          expect(page).to_not have_css('.top-bar-section .new-updates')
+          expect(page).to_not have_text('NEW PRODUCT UPDATES')
+        end
+
+        context 're visiting the site' do
+          scenario 'should not display the popup' do
+            visit arbor_reloaded_root_path
+
+            expect(page).to_not have_css('.top-bar-section .new-updates')
+            expect(page).to_not have_text('NEW PRODUCT UPDATES')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/arbor_reloaded/user_profile/edit_user_profile_spec.rb
+++ b/spec/features/arbor_reloaded/user_profile/edit_user_profile_spec.rb
@@ -13,7 +13,7 @@ feature 'User profile', js:true do
     end
 
     scenario 'I should be able to update my password' do
-      within ("form#edit_user_#{user.id}") do
+      within("form#edit_user_#{user.id}") do
         find('#user_password').set('12345678')
         find('#user_password_confirmation').set('12345678')
         find('#user_current_password').set(user.password)
@@ -31,7 +31,7 @@ feature 'User profile', js:true do
     end
 
     scenario 'I should not be able to change password with different passwords' do
-      within ("form#edit_user_#{user.id}") do
+      within("form#edit_user_#{user.id}") do
         find('#user_password').set('12345678')
         find('#user_password_confirmation').set('12345678910')
         find('#user_current_password').set(user.password)
@@ -42,7 +42,7 @@ feature 'User profile', js:true do
     end
 
     scenario 'I should not be able to submit profile changes with wrong password' do
-      within ("form#edit_user_#{user.id}") do
+      within("form#edit_user_#{user.id}") do
         find('#user_email').set('test@getarbor.io')
         find('#user_current_password').set('wrong_password')
         click_button('Save')

--- a/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
+++ b/spec/features/arbor_reloaded/user_stories/create_story_spec.rb
@@ -12,6 +12,7 @@ feature 'Create user story', js: true do
   background do
     sign_in user
     visit arbor_reloaded_project_user_stories_path(project)
+    find('.show-updates-popup').click
   end
 
   scenario 'should show control for switching mode' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ Spork.prefork do
   ENV['ENABLE_INTERCOM'] = 'true'
   ENV['SLACK_CLIENT_ID']= 'VALID_SLACK_CLIENT_ID'
   ENV['SLACK_CLIENT_SECRET'] = 'CLIENT_SECRET'
+  ENV['UPDATES_URL'] = 'http://example.com'
 
   require File.expand_path('../../config/environment', __FILE__)
   require 'rspec/rails'


### PR DESCRIPTION
# Add Updates popup

This is adds the updates link and a popup that will open everytime the
page is loaded until the user either clicks 'dismiss' or 'learn more'.
The popup can be shown/hidden using the star on the menu.

## Trello card reference

[Trello card #916](https://trello.com/c/0Yw2P3QJ/916-add-an-updates-button-on-the-top-menu-bar)