### PR TITLE
Remove current project from duplicate modal

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,6 +29,8 @@ class Project < ActiveRecord::Base
   scope :recent, -> { order(updated_at: :desc) }
   scope :by_name, -> { order('LOWER(name)') }
 
+  scope :exclude_project, ->(project) { where.not(id: project.id) }
+
   after_commit :owner_as_member
 
   scope :by_teams, ->(teams) { where(team_id: teams.pluck(:id)) }

--- a/app/views/arbor_reloaded/user_stories/index.html.haml
+++ b/app/views/arbor_reloaded/user_stories/index.html.haml
@@ -12,7 +12,7 @@
   .user-stories-container
     = render 'arbor_reloaded/user_stories/user_stories_list', project: @project, new_group_top: @new_group_top, new_group_bottom: @new_group_bottom
 = render 'arbor_reloaded/user_stories/story_delete_modal', project: @project
-= render 'arbor_reloaded/user_stories/copy_stories_modal', projects: @projects
+= render 'arbor_reloaded/user_stories/copy_stories_modal', projects: @projects.exclude_project(@project)
 
 - if @google_sheets_response.present?
   :javascript

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,6 +20,18 @@ describe Project do
   it { should_not validate_uniqueness_of(:is_template) }
   it { should validate_numericality_of(:velocity).is_greater_than_or_equal_to(0).allow_nil }
 
+  feature '#exclude_project' do
+    before do
+      create_list(:project, 3)
+    end
+
+    scenario 'removes a project from the scope' do
+      project = create(:project)
+
+      expect(Project.exclude_project(project)).to_not include(project)
+    end
+  end
+
   context 'if is_tremplate is true' do
     before :each do
       project.update_attributes(is_template: true)


### PR DESCRIPTION
# Duplicate stories on the same project

When the user tries to duplicate a story into the same project, it wont work. This will remove current project from the target projects list on the duplicate stories modal.

## Trello card reference

[Trello card #911](https://trello.com/c/V4k2QrIX/911-qa-bug-911-it-does-not-duplicate-the-stories)