### PR TITLE
Fix points_per_week on projects with no velocity

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,7 +53,7 @@ class Project < ActiveRecord::Base
 
   def points_per_week
     points = total_points
-    return points if velocity > points
+    return points if velocity.blank? && velocity > points
 
     velocity
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     sequence(:slack_channel_id) { |n| Faker::Lorem.word + "(#{n})" }
     owner                       { create :user }
     copies                      0
+    velocity                    { rand(0..100) }
   end
 
   trait :with_team do

--- a/spec/features/arbor_reloaded/project/backlog_spec.rb
+++ b/spec/features/arbor_reloaded/project/backlog_spec.rb
@@ -58,8 +58,10 @@ feature 'Project backlog', js: true do
     end
 
     scenario 'the velocity is not updated on database when is negative' do
-      set_project_velocity(-1)
-      expect(project.reload.velocity).to be(nil)
+      expect{
+        set_project_velocity(-1)
+        project.reload
+      }.not_to change(project, :velocity)
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -67,4 +67,18 @@ describe Project do
       expect(project.members).to include(project.owner)
     end
   end
+
+  describe '#points_per_week' do
+    context 'when having velocity' do
+      let(:project) { create :project, velocity: 1 }
+
+      it { expect(project.points_per_week).to eq 1 }
+    end
+
+    context 'when not having velocity' do
+      let(:project) { create :project, velocity: 0 }
+
+      it { expect(project.points_per_week).to eq 0 }
+    end
+  end
 end


### PR DESCRIPTION
Small fix for projects with no velocity set.
This happened when exporting project to Google Sheets.