### PR TITLE
Override DeviseHelper to change how errors are displayed.

### DIFF
--- a/app/assets/stylesheets/arbor_reloaded/_user_session.scss
+++ b/app/assets/stylesheets/arbor_reloaded/_user_session.scss
@@ -31,7 +31,8 @@
   #error_explanation {
     background-color: $white;
     margin-bottom: rem-calc(20);
-    padding: rem-calc(20);
+    padding: rem-calc(10) rem-calc(20);
+    text-align: center;
   }
 
   .register {

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,21 @@
+module DeviseHelper
+  def devise_error_messages!
+    return '' unless devise_error_messages?
+
+    messages = resource.errors.full_messages.map do |msg|
+      content_tag(:li, msg)
+    end.join
+
+    html = <<-HTML
+    <div id="error_explanation">
+      <ul>#{messages}</ul>
+    </div>
+    HTML
+
+    html.html_safe
+  end
+
+  def devise_error_messages?
+    resource.errors.any?
+  end
+end


### PR DESCRIPTION
## Forgot my password

#### Trello board reference:

* [Trello Card #710](https://trello.com/c/tQgjc3oF)

---

#### Description:

* Fix on how errors were presented to the user on a Devise form.

---

#### Tasks:

  - [x] Override of Devise error display method.

#### Risk:

* Low

#### Preview
<img width="402" alt="screen shot 2017-02-17 at 5 45 59 pm" src="https://cloud.githubusercontent.com/assets/5388243/23082642/fc7994de-f538-11e6-9374-2a7a0e139584.png">

